### PR TITLE
Add missing user-interest-achievement-earned notification config

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -147,6 +147,9 @@
 				},
 				"user-interest-talk-page-edit": {
 					"importance": 9
+				},
+				"user-interest-achievement-earned": {
+					"importance": 0
 				}
 			},
 			"merge_strategy": "array_plus_2d"


### PR DESCRIPTION
~14% of all UCP logs are PHP notices due to missing "user-interest-achievement-earned" notification configuration. Let's add proper defaults for this notification.

Example error:
```
PHP Notice: Undefined index: user-interest-achievement-earned in /extensions/Reverb/includes/Notification/Notification.php on line 441
	#0 /extensions/Reverb/includes/Notification/Notification.php(441): MWExceptionHandler::handleError(integer, string, string, integer, array)
	#1 /extensions/Reverb/includes/Notification/Notification.php(482): Reverb\Notification\Notification->getImportance()
	#2 /extensions/Reverb/includes/Api/ApiNotifications.php(95): Reverb\Notification\Notification->toArray()
	#3 /extensions/Reverb/includes/Api/ApiNotifications.php(39): Reverb\Api\ApiNotifications->getNotificationsForUser()
	#4 /includes/api/ApiMain.php(1593): Reverb\Api\ApiNotifications->execute()
	#5 /includes/api/ApiMain.php(531): ApiMain->executeAction()
	#6 /includes/api/ApiMain.php(502): ApiMain->executeActionWithErrorHandling()
	#7 /api.php(87): ApiMain->execute()
	#8 {main}
```