### PR TITLE
Use guzzle7-adapter for php-http on 1.37

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "require": {
         "hydrawiki/reverb-client": "^0.1",
         "php-http/discovery": "^1.6",
-        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/guzzle7-adapter": "^1.0",
         "php-http/message": "^1.7"
     },
     "require-dev": {


### PR DESCRIPTION
MW 1.37 requires Guzzle 7, so use the appropriate adapter package for
that.