### PR TITLE
Vendor Reverb client code

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,37 @@
+name: PHP tests
+
+on:
+  pull_request:
+    branches: ['**']
+
+  push:
+    branches: [ master, MW_1_37 ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shivammathur/setup-php@2.22.0
+        with:
+          php-version: '8.0'
+
+      - uses: actions/checkout@v3
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run tests
+        run: composer client-test

--- a/client/V1/Api/Api.php
+++ b/client/V1/Api/Api.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Api;
+
+use Http\Client\HttpClient;
+use Psr\Http\Message\RequestInterface;
+
+class Api
+{
+    /**
+     * HTTP Client repsonsible for making requests.
+     *
+     * @var \Http\Client\HttpClient
+     */
+    protected $client;
+
+    /**
+     * Factory responsible for creating Requests and Responses.
+     *
+     * @var \Hydrawiki\Reverb\Client\V1\Api\MessageFactory
+     */
+    protected $messageFactory;
+
+    /**
+     * Constructs a new API instance.
+     *
+     * @param \Http\Client\HttpClient                        $client
+     * @param \Hydrawiki\Reverb\Client\V1\Api\MessageFactory $messageFactory
+     */
+    public function __construct(
+        HttpClient $client,
+        MessageFactory $messageFactory
+    ) {
+        $this->client = $client;
+        $this->messageFactory = $messageFactory;
+    }
+
+    /**
+     * Make a GET request to the API.
+     *
+     * @param string $path
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse
+     */
+    public function get(string $path): JsonApiResponse
+    {
+        $request = $this->messageFactory->createRequest('GET', $path);
+
+        return $this->sendRequest($request);
+    }
+
+    /**
+     * Make a POST request to the API with data.
+     *
+     * @param string $path
+     * @param array  $data
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse
+     */
+    public function post(string $path, array $data): JsonApiResponse
+    {
+        $request = $this->messageFactory->createRequest('POST', $path, json_encode($data));
+
+        return $this->sendRequest($request);
+    }
+
+    /**
+     * Make a PATCH request to the API with data.
+     *
+     * @param string $path
+     * @param array  $data
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse
+     */
+    public function patch(string $path, array $data): JsonApiResponse
+    {
+        $request = $this->messageFactory->createRequest('PATCH', $path, json_encode($data));
+
+        return $this->sendRequest($request);
+    }
+
+    /**
+     * Make a DELETE request to the API with optional data.
+     *
+     * @param string     $path
+     * @param array|null $data
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse
+     */
+    public function delete(string $path, ?array $data = null): JsonApiResponse
+    {
+        $body = is_array($data) ? json_encode($data) : null;
+
+        $request = $this->messageFactory->createRequest('DELETE', $path, $body);
+
+        return $this->sendRequest($request);
+    }
+
+    /**
+     * Send the request and return a JSON API Response.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse
+     */
+    protected function sendRequest(RequestInterface $request): JsonApiResponse
+    {
+        $response = $this->client->sendRequest($request);
+
+        return $this->messageFactory->createResponse(
+            $response->getStatusCode(),
+            (string) $response->getBody()
+        );
+    }
+}

--- a/client/V1/Api/Document.php
+++ b/client/V1/Api/Document.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Api;
+
+use Hydrawiki\Reverb\Client\V1\Collections\Resources;
+use WoohooLabs\Yang\JsonApi\Schema\Document as YangDocument;
+
+class Document
+{
+    /**
+     * Yang Document.
+     *
+     * @var \WoohooLabs\Yang\JsonApi\Schema\Document
+     */
+    protected $document;
+
+    /**
+     * Constructs a new Document wrapper around a Yang Document.
+     *
+     * @param \WoohooLabs\Yang\JsonApi\Schema\Document $document
+     */
+    public function __construct(YangDocument $document)
+    {
+        $this->document = $document;
+    }
+
+    /**
+     * Get all (primary, included) resources that are in the Document.
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     */
+    public function allResources(): Resources
+    {
+        return $this->primaryResources()->merge($this->includedResources());
+    }
+
+    /**
+     * Get primary resources that are in the Document.
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     */
+    public function primaryResources(): Resources
+    {
+        $type = $this->isOne() ? 'primaryResource' : 'primaryResources';
+
+        $resources = (new Resources())->wrap($this->document->{$type}());
+
+        $resources = $this->wrapAsResourceObjects($resources);
+
+        $resources->setMeta($this->document->meta() ?? []);
+
+        return $resources;
+    }
+
+    /**
+     * Get resources that were included in the document.
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     */
+    public function includedResources(): Resources
+    {
+        return $this->wrapAsResourceObjects(new Resources($this->document->includedResources()));
+    }
+
+    /**
+     * Does the Document provide a single primary resource?
+     *
+     * @return bool
+     */
+    public function isOne(): bool
+    {
+        return $this->document->isSingleResourceDocument();
+    }
+
+    /**
+     * Does the document provide many primary resources?
+     *
+     * @return bool
+     */
+    public function isMany(): bool
+    {
+        return $this->document->isResourceCollectionDocument();
+    }
+
+    /**
+     * Wrap each Yang ResourceObject in our own ResourceObject class.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     */
+    protected function wrapAsResourceObjects(Resources $objects): Resources
+    {
+        return $objects->map(function ($object) {
+            return new ResourceObject($object);
+        });
+    }
+}

--- a/client/V1/Api/JsonApiResponse.php
+++ b/client/V1/Api/JsonApiResponse.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Api;
+
+use Hydrawiki\Reverb\Client\V1\Exceptions\DocumentMissing;
+
+class JsonApiResponse
+{
+    /**
+     * Response HTTP Status Code.
+     *
+     * @var int
+     */
+    protected $statusCode;
+
+    /**
+     * Optional Document included in the Response.
+     *
+     * @var \Hydrawiki\Reverb\Client\V1\Api\Document|null
+     */
+    protected $document;
+
+    /**
+     * Constructs a new JSON API Response.
+     *
+     * @param int                                           $statusCode
+     * @param \Hydrawiki\Reverb\Client\V1\Api\Document|null $document
+     */
+    public function __construct(int $statusCode, ?Document $document = null)
+    {
+        $this->statusCode = $statusCode;
+        $this->document = $document;
+    }
+
+    /**
+     * Does the response have a Document?
+     *
+     * @return bool
+     */
+    public function hasDocument(): bool
+    {
+        return ! is_null($this->document);
+    }
+
+    /**
+     * Get the response Document.
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Api\Document
+     */
+    public function document(): Document
+    {
+        if (! $this->hasDocument()) {
+            throw DocumentMissing::fromResponse();
+        }
+
+        return $this->document;
+    }
+
+    /**
+     * Is this a successful response to an Index request?
+     *
+     * @return bool
+     */
+    public function isSuccessfulIndex(): bool
+    {
+        return $this->isStatusCode([200]) && $this->hasDocument() && $this->document()->isMany();
+    }
+
+    /**
+     * Is this a successful response to a Read request?
+     *
+     * @return bool
+     */
+    public function isSuccessfulRead(): bool
+    {
+        return $this->isStatusCode([200]) && $this->hasDocument() && $this->document()->isOne();
+    }
+
+    /**
+     * Is this a successful response to a Create request?
+     *
+     * @return bool
+     */
+    public function isSuccessfulCreate(): bool
+    {
+        return $this->isStatusCode([201]) && $this->hasDocument() && $this->document()->isOne();
+    }
+
+    /**
+     * Is this a successful response to an Update request?
+     *
+     * @return bool
+     */
+    public function isSuccessfulUpdate(): bool
+    {
+        return $this->isSuccessfulUpdateWithDocument() OR $this->isSuccessfulUpdateWithoutDocument();
+    }
+
+    /**
+     * Get the HTTP Status Code of the response.
+     *
+     * @return int
+     */
+    public function statusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * Is this a successful response to an Update request with a document?
+     *
+     * @return bool
+     */
+    protected function isSuccessfulUpdateWithDocument(): bool
+    {
+        return $this->isStatusCode([200]) && $this->hasDocument() && $this->document()->isOne();
+    }
+
+    /**
+     * Is this a successful response to an Update request without a document?
+     *
+     * @return bool
+     */
+    protected function isSuccessfulUpdateWithoutDocument(): bool
+    {
+        return $this->isStatusCode([204]) && ! $this->hasDocument();
+    }
+
+    /**
+     * Does the HTTP Status Code match any of these status codes?
+     *
+     * @param array $statusCodes
+     *
+     * @return bool
+     */
+    protected function isStatusCode(array $statusCodes): bool
+    {
+        return in_array($this->statusCode, $statusCodes);
+    }
+}

--- a/client/V1/Api/MessageFactory.php
+++ b/client/V1/Api/MessageFactory.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Api;
+
+use Http\Message\MessageFactory as HttpMessageFactory;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ApiResponseInvalid;
+use Psr\Http\Message\RequestInterface;
+use WoohooLabs\Yang\JsonApi\Schema\Document as YangDocument;
+
+class MessageFactory
+{
+    /**
+     * HTTP Message Factory.
+     *
+     * @var \Http\Message\MessageFactory
+     */
+    protected $httpMessageFactory;
+
+    /**
+     * API Endpoint for all requests.
+     *
+     * @var string
+     */
+    protected $endpoint;
+
+    /**
+     * Headers included with the request.
+     *
+     * @var array
+     */
+    protected $headers;
+
+    /**
+     * Constructs a new Message Factory.
+     *
+     * @param \Http\Message\MessageFactory $httpMessageFactory
+     * @param string                       $endpoint
+     * @param array                        $headers
+     */
+    public function __construct(
+        HttpMessageFactory $httpMessageFactory,
+        string $endpoint,
+        array $headers = []
+    ) {
+        $this->httpMessageFactory = $httpMessageFactory;
+        $this->endpoint = $endpoint;
+        $this->headers = array_merge([
+            'Accept'       => 'application/vnd.api+json',
+            'Content-Type' => 'application/vnd.api+json',
+        ], $headers);
+    }
+
+    /**
+     * Create a request through the Message Factory, using the headers and
+     * API endpoint.
+     *
+     * @param string      $method
+     * @param string      $path
+     * @param string|null $body
+     *
+     * @return \Psr\Http\Message\RequestInterface
+     */
+    public function createRequest(
+        string $method,
+        string $path,
+        ?string $body = null
+    ): RequestInterface {
+        return $this->httpMessageFactory->createRequest(
+            $method,
+            "{$this->endpoint}/{$path}",
+            $this->headers,
+            $body
+        );
+    }
+
+    /**
+     * Create a JsonApiResponse from a Response body.
+     *
+     * @param int         $statusCode
+     * @param string|null $response
+     *
+     * @throws \Hydrawiki\Reverb\Client\V1\Exceptions\ApiResponseInvalid
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse
+     */
+    public function createResponse(int $statusCode = 200, ?string $response = null): JsonApiResponse
+    {
+        if (is_string($response) && $response !== '') {
+            $properties = json_decode($response, true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw ApiResponseInvalid::json($response);
+            }
+
+            $document = new Document(
+                YangDocument::fromArray($properties)
+            );
+        }
+
+        return new JsonApiResponse($statusCode, $document ?? null);
+    }
+}

--- a/client/V1/Api/ResourceObject.php
+++ b/client/V1/Api/ResourceObject.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Api;
+
+use Tightenco\Collect\Support\Collection;
+use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject as YangResourceObject;
+
+class ResourceObject
+{
+    /**
+     * Yang Resource Object.
+     *
+     * @var \WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject
+     */
+    protected $resourceObject;
+
+    /**
+     * Constructs a Resource Object wrapper around a Yang Resource Object.
+     *
+     * @param \WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject $resourceObject
+     */
+    public function __construct(YangResourceObject $resourceObject)
+    {
+        $this->resourceObject = $resourceObject;
+    }
+
+    /**
+     * Get a unique key for the object.
+     *
+     * @return string
+     */
+    public function key(): string
+    {
+        return "{$this->type()}.{$this->id()}";
+    }
+
+    /**
+     * Get the type of object.
+     *
+     * @return string
+     */
+    public function type(): string
+    {
+        return $this->resourceObject->type();
+    }
+
+    /**
+     * Get the unique ID of the object.
+     *
+     * @return string
+     */
+    public function id(): string
+    {
+        return $this->resourceObject->id();
+    }
+
+    /**
+     * Get the attributes of the object.
+     *
+     * @return array
+     */
+    public function attributes(): array
+    {
+        return $this->resourceObject->attributes();
+    }
+
+    /**
+     * Get the metadata of the object.
+     *
+     * @return array
+     */
+    public function meta(): array
+    {
+        return $this->resourceObject->meta();
+    }
+
+    /**
+     * Get the object's relations in a relationship => [[type, id], [type, id]]
+     * set.
+     *
+     * @return \Tightenco\Collect\Support\Collection
+     */
+    public function relations(): Collection
+    {
+        return (new Collection($this->resourceObject->relationships()))
+            ->mapWithKeys(function ($relationship) {
+                return [$relationship->name() => $relationship->resourceLinks()];
+            });
+    }
+}

--- a/client/V1/Client.php
+++ b/client/V1/Client.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1;
+
+use Hydrawiki\Reverb\Client\V1\Api\Api;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ApiRequestUnsuccessful;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ClientResourceCall;
+use Hydrawiki\Reverb\Client\V1\Hydrators\Hydrator;
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use Hydrawiki\Reverb\Client\V1\Collections\Resources;
+use Tightenco\Collect\Support\Collection;
+
+class Client
+{
+    /**
+     * API Client responsible for making requests.
+     *
+     * @var \Hydrawiki\Reverb\Client\V1\Api\Api
+     */
+    protected $api;
+
+    /**
+     * Hydrator responsible for transforming Document into one or many entities.
+     *
+     * @var \Hydrawiki\Reverb\Client\V1\Hydrators\Hydrator
+     */
+    protected $hydrator;
+
+    /**
+     * Resources used to build the request path.
+     *
+     * @var \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     */
+    protected $resources;
+
+    /**
+     * Parameters to include as the request's query string.
+     *
+     * @var \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     */
+    protected $parameters;
+
+    /**
+     * Constructs a new Client.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Api\Api      $api
+     * @param \Hydrawiki\Reverb\Client\V1\Hydrators\Hydrator $hydrator
+     */
+    public function __construct(Api $api, Hydrator $hydrator)
+    {
+        $this->api = $api;
+        $this->hydrator = $hydrator;
+        $this->newCollectionState();
+    }
+
+    /**
+     * Add a resource to the request path, e.g: `wikis()`.
+     *
+     * @param string $resource
+     * @param array  $parameters
+     *
+     * @throws \Hydrawiki\Reverb\Client\V1\Exceptions\ClientResourceCall
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Client
+     */
+    public function __call(string $resource, array $parameters)
+    {
+        if (count($parameters) > 1) {
+            throw ClientResourceCall::parameters($parameters);
+        }
+
+        $object = reset($parameters);
+
+        if ($object && !$object instanceof Resource) {
+            throw ClientResourceCall::type($object);
+        }
+
+        $this->resources->push(new Collection([
+            'type'   => str_replace('_', '-', $resource),
+            'object' => $object,
+        ]));
+
+        return $this;
+    }
+
+    /**
+     * Retrieve an index of a Resource with all primary resources hydrated.
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     */
+    public function all(): Resources
+    {
+        $response = $this->api->get($this->compilePath());
+
+        if (!$response->isSuccessfulIndex()) {
+            throw ApiRequestUnsuccessful::index($response);
+        }
+
+        return $this->hydrator->hydrate($response->document());
+    }
+
+    /**
+     * Find a single Resource by its ID.
+     *
+     * @param string $id
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resources\Resource
+     */
+    public function find(string $id): Resource
+    {
+        $response = $this->api->get($this->compilePath($id));
+
+        if (!$response->isSuccessfulRead()) {
+            throw ApiRequestUnsuccessful::read($response);
+        }
+
+        return $this->hydrator->hydrate($response->document());
+    }
+
+    /**
+     * Add one or more relations to be included.
+     *
+     * @param string ...$relations
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Client
+     */
+    public function include(string ...$relations): self
+    {
+        $this->parameters->put(
+            'includes',
+            $this->parameters->get('includes', []) + $relations
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add filters to the query.
+     *
+     * @param array $filters
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Client
+     */
+    public function filter(array $filters): self
+    {
+        $this->parameters->put(
+            'filters',
+            $this->parameters->get('filters', []) + $filters
+        );
+
+        return $this;
+    }
+
+
+    /**
+     * Set the page (limit, offset) for the request.
+     *
+     * @param int $limit
+     * @param int $offset
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Client
+     */
+    public function page(int $limit, int $offset): self
+    {
+        $this->parameters->put('pagination', [
+            'limit' => $limit,
+            'offset' => $offset,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * Create a new Resource.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Resources\Resource $resource
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resources\Resource
+     */
+    public function create(Resource $resource): Resource
+    {
+        $response = $this->api->post(
+            $this->compilePath(),
+            $resource->toData()
+        );
+
+        if (! $response->isSuccessfulCreate()) {
+            throw ApiRequestUnsuccessful::create($response);
+        }
+
+        return $this->hydrator->hydrate($response->document());
+    }
+
+    /**
+     * Update a Resource. If the service returns a Document, hydrate a Resource
+     * otherwise return the Resource as-is.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Resources\Resource $resource
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resources\Resource
+     */
+    public function update(Resource $resource): Resource
+    {
+        $response = $this->api->patch(
+            "{$resource->type()}/{$resource->id()}",
+            $resource->toData()
+        );
+
+        if (! $response->isSuccessfulUpdate()) {
+            throw ApiRequestUnsuccessful::update($response);
+        }
+
+        if ($response->hasDocument()) {
+            return $this->hydrator->hydrate($response->document());
+        }
+
+        return $resource;
+    }
+
+    /**
+     * Compile the path for the request, resetting the client state.
+     *
+     * @param string|null $id
+     *
+     * @return string
+     */
+    protected function compilePath(?string $id = null): string
+    {
+        $path = $this->resources
+            ->map(function ($resource) {
+                return [
+                    $resource->get('type'),
+                    $resource->get('object') ? $resource->get('object')->id() : null,
+                ];
+            })
+            ->flatten()
+            ->merge($id)
+            ->filter()
+            ->implode('/');
+
+        $query = $this->queryString();
+
+        $this->newCollectionState();
+
+        return $path.($query ? "?{$query}" : '');
+    }
+
+    /**
+     * Build the query string for the request.
+     *
+     * @return string
+     */
+    protected function queryString(): string
+    {
+        return http_build_query(array_merge(
+            $this->includes(),
+            $this->pagination(),
+            $this->filters()
+        ));
+    }
+
+    /**
+     * Get the list of relations to include in the request.
+     *
+     * @return array
+     */
+    protected function includes(): array
+    {
+        $includes = $this->parameters->get('includes', []);
+
+        return $includes ? ['include' => implode(',', $includes)] : [];
+    }
+
+    /**
+     * Get the filters to include in the request.
+     *
+     * @return array
+     */
+    protected function filters(): array
+    {
+        $filters = $this->parameters->get('filters', []);
+
+        return $filters ? ['filter' => $filters] : [];
+    }
+
+    /**
+     * Get the pagination parameters to include in the request.
+     *
+     * @return array
+     */
+    protected function pagination(): array
+    {
+        $pagination = $this->parameters->get('pagination', []);
+
+        return $pagination ? ['page' => $pagination] : [];
+    }
+
+    /**
+     * Reset the state of the collections used by the client.
+     *
+     * @return void
+     */
+    protected function newCollectionState(): void
+    {
+        $this->resources = new Collection();
+        $this->parameters = new Collection();
+    }
+}

--- a/client/V1/ClientFactory.php
+++ b/client/V1/ClientFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1;
+
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory as MessageFactoryInterface;
+use Hydrawiki\Reverb\Client\V1\Api\Api;
+use Hydrawiki\Reverb\Client\V1\Api\MessageFactory;
+use Hydrawiki\Reverb\Client\V1\Hydrators\ResourceHydrator;
+use Hydrawiki\Reverb\Client\V1\Hydrators\ResourceFactory;
+
+class ClientFactory
+{
+    /**
+     * Resource types and their companion Resource.
+     *
+     * @var \Hydrawiki\Reverb\Client\V1\Resources\Resource[]
+     */
+    protected $resources = [
+        'notifications' => \Hydrawiki\Reverb\Client\V1\Resources\Notification::class,
+        'notification-broadcasts' => \Hydrawiki\Reverb\Client\V1\Resources\NotificationBroadcast::class,
+        'notification-dismissals' => \Hydrawiki\Reverb\Client\V1\Resources\NotificationDismissals::class,
+        'notification-targets' => \Hydrawiki\Reverb\Client\V1\Resources\NotificationTarget::class,
+        'sites' => \Hydrawiki\Reverb\Client\V1\Resources\Site::class,
+        'users' => \Hydrawiki\Reverb\Client\V1\Resources\User::class,
+    ];
+
+    /**
+     * Make a new Hydraulics Client using the HTTP Client, message factory and
+     * endpoint provided by the package user.
+     *
+     * @param \Http\Client\HttpClient      $http
+     * @param \Http\Message\MessageFactory $messageFactory
+     * @param string                       $endpoint
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Client
+     */
+    public function make(
+        HttpClient $http,
+        MessageFactoryInterface $messageFactory,
+        string $endpoint,
+        string $apiKey
+    ): Client {
+        $api = new Api(
+            $http,
+            new MessageFactory($messageFactory, $endpoint, ['Authorization' => $apiKey])
+        );
+
+        $hydrator = new ResourceHydrator(
+            new ResourceFactory($this->resources)
+        );
+
+        return new Client($api, $hydrator);
+    }
+}

--- a/client/V1/Collections/Resources.php
+++ b/client/V1/Collections/Resources.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Collections;
+
+use Tightenco\Collect\Support\Collection;
+
+class Resources extends Collection
+{
+    /**
+     * Meta data associated with the Resources.
+     *
+     * @var array
+     */
+    protected $meta = [];
+
+    /**
+     * Set the meta.
+     *
+     * @param array $meta
+     *
+     * @return void
+     */
+    public function setMeta(array $meta): void
+    {
+        $this->meta = $meta;
+    }
+
+    /**
+     * Get the meta.
+     *
+     * @return array
+     */
+    public function meta(): array
+    {
+        return $this->meta;
+    }
+
+    /**
+     * Map items to a callback -- return same instance but with new items.
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Collections\Resources
+     */
+    public function map(callable $callback)
+    {
+        $keys = array_keys($this->items);
+        $items = array_map($callback, $this->items, $keys);
+
+        $this->replaceAllItems(array_combine($keys, $items));
+
+        return $this;
+    }
+
+    /**
+     * Replace all items in the Collection.
+     *
+     * @param array $items
+     *
+     * @return void
+     */
+    protected function replaceAllItems(array $items): void
+    {
+        $this->items = $items;
+    }
+}

--- a/client/V1/Exceptions/ApiRequestUnsuccessful.php
+++ b/client/V1/Exceptions/ApiRequestUnsuccessful.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Exceptions;
+
+use Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse;
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use LogicException;
+
+class ApiRequestUnsuccessful extends LogicException
+{
+    /**
+     * API Response was not successful for an Index request.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse $response
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ApiResponseFailed
+     */
+    public static function index(JsonApiResponse $response): self
+    {
+        return new static('Index resource request to API was not successful.');
+    }
+
+    /**
+     * API Response was not successful for a Read request.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse $response
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ApiResponseFailed
+     */
+    public static function read(JsonApiResponse $response): self
+    {
+        return new static('Read resource request to API was not successful.');
+    }
+
+    /**
+     * API Response was not successful for a Create request.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse $response
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ApiResponseFailed
+     */
+    public static function create(JsonApiResponse $response): self
+    {
+        return new static('Create resource request to API was not successful.');
+    }
+
+    /**
+     * API Response was not successful for an Update request.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse $response
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ApiResponseFailed
+     */
+    public static function update(JsonApiResponse $response): self
+    {
+        return new static('Update resource request to API was not successful.');
+    }
+}

--- a/client/V1/Exceptions/ApiResponseInvalid.php
+++ b/client/V1/Exceptions/ApiResponseInvalid.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Exceptions;
+
+use RuntimeException;
+
+class ApiResponseInvalid extends RuntimeException
+{
+    /**
+     * API response is not valid JSON.
+     *
+     * @param string $response
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ApiResponseInvalid
+     */
+    public static function json(string $response): self
+    {
+        return new static("Response body `{$response}` is not valid JSON.");
+    }
+}

--- a/client/V1/Exceptions/ClientResourceCall.php
+++ b/client/V1/Exceptions/ClientResourceCall.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Exceptions;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use LogicException;
+
+class ClientResourceCall extends LogicException
+{
+    /**
+     * The resource call has too many parameters.
+     *
+     * @param array $parameters
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ClientResourceCall
+     */
+    public static function parameters(array $parameters): self
+    {
+        return new static('Resource calls expect 1 parameter maximum, received '.count($parameters));
+    }
+
+    /**
+     * The object passed to the resource call is not a Resource.
+     *
+     * @param object $object
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ClientResourceCall
+     */
+    public static function type(Object $object): self
+    {
+        return new static('Resource call expects a Resource, received '.get_class($object));
+    }
+}

--- a/client/V1/Exceptions/DocumentMissing.php
+++ b/client/V1/Exceptions/DocumentMissing.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Exceptions;
+
+use RuntimeException;
+
+class DocumentMissing extends RuntimeException
+{
+    /**
+     * A Document is missing from the response.
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\DocumentMissing
+     */
+    public static function fromResponse(): self
+    {
+        return new static('Response does not contain a valid JSON:API Document.');
+    }
+}

--- a/client/V1/Exceptions/ResourceAlreadyPopulated.php
+++ b/client/V1/Exceptions/ResourceAlreadyPopulated.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Exceptions;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use LogicException;
+
+class ResourceAlreadyPopulated extends LogicException
+{
+    /**
+     * The Resource has already been populated with attributes.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Resources\Resource $resource
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAlreadyPopulated
+     */
+    public static function resource(Resource $resource): self
+    {
+        return new static('Resource has already been populated, use `update()` to make changes.');
+    }
+}

--- a/client/V1/Exceptions/ResourceAttributeUndefined.php
+++ b/client/V1/Exceptions/ResourceAttributeUndefined.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Exceptions;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use LogicException;
+
+class ResourceAttributeUndefined extends LogicException
+{
+    /**
+     * The attribute has not been defined as part of the Resource.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Resources\Resource $resource
+     * @param string                                   $attribute
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAttributeUndefined
+     */
+    public static function attribute(Resource $resource, string $attribute): self
+    {
+        return new static("Attribute {$attribute} does not exist on Resource ".get_class($resource));
+    }
+}

--- a/client/V1/Exceptions/ResourceRelationshipUndefined.php
+++ b/client/V1/Exceptions/ResourceRelationshipUndefined.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Exceptions;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use LogicException;
+
+class ResourceRelationshipUndefined extends LogicException
+{
+    /**
+     * The relationship has not been defined as part of the Resource.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Resources\Resource $resource
+     * @param string                                   $relationship
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceRelationshipUndefined
+     */
+    public static function relationship(Resource $resource, string $relationship): self
+    {
+        return new static("Relationship {$relationship} does not exist on Resource ".get_class($resource));
+    }
+}

--- a/client/V1/Exceptions/ResourceTypeUnmapped.php
+++ b/client/V1/Exceptions/ResourceTypeUnmapped.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Exceptions;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use LogicException;
+
+class ResourceTypeUnmapped extends LogicException
+{
+    /**
+     * The resource type has not been mapped to a Resource.
+     *
+     * @param string $type
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceTypeUnmapped
+     */
+    public static function type(string $type): self
+    {
+        return new static("Resource type {$type} has not been mapped to a Resource.");
+    }
+}

--- a/client/V1/Hydrators/Hydrator.php
+++ b/client/V1/Hydrators/Hydrator.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Hydrators;
+
+use Hydrawiki\Reverb\Client\V1\Api\Document;
+
+interface Hydrator
+{
+    /**
+     * Hydrates a Document by turning Resource Objects into entities with their
+     * attributes and relations. Returns either a single primary resource or a
+     * Collection of primary resources depending on the Document type.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Api\Document $document
+     *
+     * @return \Tightenco\Collect\Support\Collection|\Hydrawiki\Reverb\Client\V1\Resources\Resource
+     */
+    public function hydrate(Document $document);
+}

--- a/client/V1/Hydrators/ResourceFactory.php
+++ b/client/V1/Hydrators/ResourceFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Hydrators;
+
+use Hydrawiki\Reverb\Client\V1\Exceptions\ResourceTypeUnmapped;
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+
+class ResourceFactory
+{
+    /**
+     * Resource Object type to Resource.
+     *
+     * @var array
+     */
+    protected $resourceMap;
+
+    /**
+     * Map of Resource Object types (from the API) to local Resources.
+     *
+     * @param array $resourceMap
+     */
+    public function __construct(array $resourceMap)
+    {
+        $this->resourceMap = $resourceMap;
+    }
+
+    /**
+     * Make a Resource from a ResourceObject.
+     *
+     * @param string $type
+     *
+     * @throws \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceTypeUnmapped
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resources\Resource
+     */
+    public function make(string $type): Resource
+    {
+        if (!array_key_exists($type, $this->resourceMap)) {
+            throw ResourceTypeUnmapped::type($type);
+        }
+
+        return new $this->resourceMap[$type]();
+    }
+}

--- a/client/V1/Hydrators/ResourceHydrator.php
+++ b/client/V1/Hydrators/ResourceHydrator.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Hydrators;
+
+use Hydrawiki\Reverb\Client\V1\Api\Document;
+use Hydrawiki\Reverb\Client\V1\Api\ResourceObject;
+use Tightenco\Collect\Support\Collection;
+
+class ResourceHydrator implements Hydrator
+{
+    /**
+     * Resource Factory.
+     *
+     * @var \Hydrawiki\Reverb\Client\V1\Resources\ResourceFactory
+     */
+    protected $resourceFactory;
+
+    /**
+     * Constructs a new Resource Hydrator from a Document.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Resources\ResourceFactory $resourceFactory
+     */
+    public function __construct(ResourceFactory $resourceFactory)
+    {
+        $this->resourceFactory = $resourceFactory;
+    }
+
+    /**
+     * Hydrates a Document by turning Resource Objects into Resources with their
+     * attributes and relations. Returns either a single primary resource or a
+     * Collection of primary resources depending on the Document type.
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Api\Document $document
+     *
+     * @return \Tightenco\Collect\Support\Collection|\Hydrawiki\Reverb\Client\V1\Resources\Resource
+     */
+    public function hydrate(Document $document)
+    {
+        $resources = $document->allResources()->mapWithKeys(function ($object) {
+            return [$object->key() => $this->resourceFactory->make($object->type())];
+        });
+
+        $document->allResources()->each(function ($object) use ($resources) {
+            $resources
+                ->get($object->key())
+                ->setId($object->id())
+                ->setAttributes($object->attributes())
+                ->setMeta($object->meta())
+                ->setRelations($this->hydrateRelations($object, $resources));
+        });
+
+        $primary = $document->primaryResources()->map(function ($primary) use ($resources) {
+            return $resources->get($primary->key());
+        });
+
+        return $document->isOne() ? $primary->first() : $primary;
+    }
+
+    /**
+     * Hydrates relations on a Resource, turning 'relationship' => [[type, id]]
+     * into 'relationship' => [Resource, Resource, Resource].
+     *
+     * @param \Hydrawiki\Reverb\Client\V1\Resources\ResourceObject $object
+     * @param \Tightenco\Collect\Support\Collection          $resources
+     *
+     * @return array
+     */
+    protected function hydrateRelations(ResourceObject $object, Collection $resources): array
+    {
+        return $object->relations()->map(function ($relations, $relationship) {
+            return (new Collection($relations))->map(function ($relation) use ($relationship) {
+                return $relation + [
+                    'relationship' => $relationship,
+                    'key'          => "{$relation['type']}.{$relation['id']}",
+                ];
+            });
+        })
+        ->flatten(1)
+        ->mapToGroups(function ($relation) use ($resources) {
+            return [$relation['relationship'] => $resources->get($relation['key'])];
+        })
+        ->toArray();
+    }
+}

--- a/client/V1/Resources/Notification.php
+++ b/client/V1/Resources/Notification.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Resources;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+
+class Notification extends Resource
+{
+    /**
+     * Resource type as per the API.
+     *
+     * @var string
+     */
+    protected $type = 'notifications';
+
+    /**
+     * Attributes provided by the API and default values.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'type'          => null,
+        'message'       => null,
+        'created-at'    => null,
+        'dismissed-at'  => null,
+        'url'           => null,
+        // Temporary workaround until the service provides these as relations
+        // see: https://gitlab.com/hydrawiki/services/reverb/issues/3
+        'agent-id'      => null,
+        'origin-id'     => null,
+    ];
+
+    /**
+     * Relationships to other Resources.
+     *
+     * @var array
+     */
+    protected $relationships = [
+        'origin' => [Site::class, self::RELATIONSHIP_ONE],
+        'agent'  => [User::class, self::RELATIONSHIP_ONE],
+        'target' => [User::class, self::RELATIONSHIP_ONE],
+    ];
+}

--- a/client/V1/Resources/NotificationBroadcast.php
+++ b/client/V1/Resources/NotificationBroadcast.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Resources;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+
+class NotificationBroadcast extends Resource
+{
+    /**
+     * Resource type as per the API.
+     *
+     * @var string
+     */
+    protected $type = 'notification-broadcasts';
+
+    /**
+     * Attributes provided by the API and default values.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'type'        => null,
+        'message'     => null,
+        'created-at'  => null,
+        'url'         => null,
+        // Temporary workaround until the service accepts these as relations
+        // see: https://gitlab.com/hydrawiki/services/reverb/issues/3
+        'origin-id'   => null,
+        'agent-id'    => null,
+        'target-ids'  => null
+    ];
+
+    /**
+     * Relationships to other Resources.
+     *
+     * @var array
+     */
+    protected $relationships = [
+        'origin'  => [Site::class, self::RELATIONSHIP_ONE],
+        'agent'   => [User::class, self::RELATIONSHIP_ONE],
+        'targets' => [User::class, self::RELATIONSHIP_MANY],
+    ];
+}

--- a/client/V1/Resources/NotificationDismissals.php
+++ b/client/V1/Resources/NotificationDismissals.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Resources;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+
+class NotificationDismissals extends Resource
+{
+    /**
+     * Resource type as per the API.
+     *
+     * @var string
+     */
+    protected $type = 'notification-dismissals';
+
+    /**
+     * Attributes provided by the API and default values.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'target-id'     => null
+    ];
+
+    /**
+     * Relationships to other Resources.
+     *
+     * @var array
+     */
+    protected $relationships = [
+        'target' => [User::class, self::RELATIONSHIP_ONE]
+    ];
+}

--- a/client/V1/Resources/NotificationTarget.php
+++ b/client/V1/Resources/NotificationTarget.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Resources;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+
+class NotificationTarget extends Resource
+{
+    /**
+     * Resource type as per the API.
+     *
+     * @var string
+     */
+    protected $type = 'notification-targets';
+
+    /**
+     * Attributes provided by the API and default values.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'created-at'     => null,
+        'dismissed-at'   => null,
+        // Temporary workaround until the service provides these as relations
+        // see: https://gitlab.com/hydrawiki/services/reverb/issues/3
+        'target-id'      => null,
+    ];
+
+    /**
+     * Relationships to other Resources.
+     *
+     * @var array
+     */
+    protected $relationships = [
+        'notification' => [Notification::class, self::RELATIONSHIP_ONE],
+    ];
+}

--- a/client/V1/Resources/Resource.php
+++ b/client/V1/Resources/Resource.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Resources;
+
+use Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAlreadyPopulated;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAttributeUndefined;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ResourceRelationshipUndefined;
+use Tightenco\Collect\Support\Collection;
+
+abstract class Resource
+{
+    /**
+     * Relationship for a single Resource.
+     *
+     * @var string
+     */
+    const RELATIONSHIP_ONE = 'toOne';
+
+    /**
+     * Relationship for many Resources.
+     *
+     * @var string
+     */
+    const RELATIONSHIP_MANY = 'toMany';
+
+    /**
+     * Resource type as per the API.
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Unique identifier for this Resource Object.
+     *
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * Whitelist of attributes and their default values.
+     *
+     * @var array
+     */
+    protected $attributes = [];
+
+    /**
+     * Meta data associated with the Resource.
+     *
+     * @var array
+     */
+    protected $meta = [];
+
+    /**
+     * Attribute's values.
+     *
+     * @var array
+     */
+    protected $values = [];
+
+    /**
+     * Relationships to other Resources.
+     *
+     * @var array
+     */
+    protected $relationships = [];
+
+    /**
+     * Resources that belong to relationships.
+     *
+     * @var \Tightenco\Collect\Support\Collection
+     */
+    protected $relations = [];
+
+    /**
+     * Constructs a new Resource with optional attribute values.
+     *
+     * @param array|null $values
+     */
+    public function __construct(?array $values = null)
+    {
+        if (is_array($values)) {
+            $this->addAttributeValues($values);
+        }
+
+        $this->relations = (new Collection($this->relationships))->map(function () {
+            return new Collection;
+        });
+    }
+
+    /**
+     * Provides access to attributes as Resource properties.
+     *
+     * @param string $attribute
+     *
+     * @throws \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAttributeUndefined
+     *
+     * @return mixed
+     */
+    public function __get(string $attribute)
+    {
+        $attribute = str_replace('_', '-', $attribute);
+
+        if (!array_key_exists($attribute, $this->attributes)) {
+            throw ResourceAttributeUndefined::attribute($this, $attribute);
+        }
+
+        return $this->values[$attribute] ?? $this->attributes[$attribute];
+    }
+
+    /**
+     * Get the relation(s) belonging to a relationship.
+     *
+     * @param string $relationship
+     * @param array  $parameters
+     *
+     * @throws \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceRelationshipUndefined
+     *
+     * @return \Tightenco\Collect\Support\Collection|\Hydrawiki\Reverb\Client\V1\Resource|null
+     */
+    public function __call(string $relationship, array $parameters)
+    {
+        if (!array_key_exists($relationship, $this->relationships)) {
+            throw ResourceRelationshipUndefined::relationship($this, $relationship);
+        }
+
+        list($resource, $type) = $this->relationships[$relationship];
+
+        return $this->{"get{$type}Relationship"}($relationship);
+    }
+
+    /**
+     * Get the Resource's ID.
+     *
+     * @return string|null
+     */
+    public function id(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the Resource's type.
+     *
+     * @return string
+     */
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Update attributes -- without persisting.
+     *
+     * @var array
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resource
+     */
+    public function update(array $values): self
+    {
+        $this->addAttributeValues($values);
+
+        return $this;
+    }
+
+    /**
+     * Get all attributes of the Resource, using default values if no value
+     * is set.
+     *
+     * @return array
+     */
+    public function attributes(): array
+    {
+        return array_merge($this->attributes, $this->values);
+    }
+
+    /**
+     * Get all changed attributes and their new values.
+     *
+     * @return array
+     */
+    public function changes(): array
+    {
+        return $this->values;
+    }
+
+    /**
+     * Get the Resource's metadata.
+     *
+     * @param string|null $key
+     *
+     * @return mixed
+     */
+    public function meta(?string $key = null)
+    {
+        return $key ? $this->meta[$key] : $this->meta;
+    }
+
+    /**
+     * Set the ID of the Resource.
+     *
+     * @param string $id
+     *
+     * @throws \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAlreadyPopulated
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resource
+     */
+    public function setId(string $id): self
+    {
+        if (!is_null($this->id)) {
+            throw ResourceAlreadyPopulated::resource($this);
+        }
+
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * Set the attributes of the Resource at the time of initialisation.
+     *
+     * @param array $values
+     *
+     * @throws \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAlreadyPopulated
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resource
+     */
+    public function setAttributes(array $values): self
+    {
+        if (!empty($this->values)) {
+            throw ResourceAlreadyPopulated::resource($this);
+        }
+
+        $this->addAttributeValues($values);
+
+        return $this;
+    }
+
+    /**
+     * Set the relations of the Resource at the time of initialisation.
+     *
+     * @param array $relations
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resource
+     */
+    public function setRelations(array $relations): self
+    {
+        $this->relations = $this->relations
+        ->filter(function ($relations, $relationship) {
+            return array_key_exists($relationship, $this->relationships);
+        })->map(function ($collection, $relationship) use ($relations) {
+            return $collection->wrap($relations[$relationship] ?? null);
+        });
+
+        return $this;
+    }
+
+    /**
+     * Add a Relation to a Relationship.
+     *
+     * @param string $relationship
+     * @param \Hydrawiki\Reverb\Client\V1\Resource ...$resources
+     *
+     * @throws \Hydrawiki\Reverb\Client\V1\Exceptions\ResourceRelationshipUndefined
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resource
+     */
+    public function add(string $relationship, Resource ...$resources): self
+    {
+        if (!array_key_exists($relationship, $this->relationships)) {
+            throw ResourceRelationshipUndefined::relationship($this, $relationship);
+        }
+
+        (new Collection($resources))->each(function ($resource) use ($relationship) {
+            $this->relations->get($relationship)->push($resource);
+        });
+
+        return $this;
+    }
+
+    /**
+     * Set the Resource's metadata.
+     *
+     * @param array $meta
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resource
+     */
+    public function setMeta(array $meta): self
+    {
+        $this->meta = $meta;
+
+        return $this;
+    }
+
+    /**
+     * Get the Resource attributes and relationships in a JSON:API data format.
+     *
+     * @return array
+     */
+    public function toData(): array
+    {
+        return [
+            'data' => array_filter([
+                'type' => $this->type,
+                'id' => $this->id,
+                'attributes' => $this->attributes(),
+                'relationships' => $this->getFilledRelationships(),
+            ]),
+        ];
+    }
+
+    /**
+     * Get relationships that are filled, in JSON:API data format.
+     *
+     * @return array
+     */
+    protected function getFilledRelationships(): array
+    {
+        return $this->relations->map(function ($resources) {
+            return $resources->reject(function ($resource) {
+                return is_null($resource->id());
+            })->map(function ($resource) {
+                return ['data' => [
+                    'id' => $resource->id(),
+                    'type' => $resource->type(),
+                ]];
+            });
+        })->reject(function ($resources) {
+            return $resources->isEmpty();
+        })->map(function ($resources, $relationship) {
+            [$resource, $type] = $this->relationships[$relationship];
+
+            return $type === 'toOne' ? $resources->first() : $resources;
+        })->toArray();
+    }
+
+    /**
+     * Get the relation for a toOne relationship.
+     *
+     * @param string $relationship
+     *
+     * @return \Hydrawiki\Reverb\Client\V1\Resource|null
+     */
+    protected function getToOneRelationship(string $relationship): ?self
+    {
+        return $this->relations[$relationship]->first();
+    }
+
+    /**
+     * Get the relations for a toMany relationship.
+     *
+     * @param string $relationship
+     *
+     * @return \Tightenco\Collect\Support\Collection
+     */
+    protected function getToManyRelationship(string $relationship): Collection
+    {
+        return $this->relations[$relationship];
+    }
+
+    /**
+     * Merge values into the attribute values.
+     *
+     * @param array $values
+     *
+     * @return array
+     */
+    protected function addAttributeValues(array $values): void
+    {
+        $this->values = array_merge(
+            $this->values,
+            array_intersect_key($values, $this->attributes)
+        );
+    }
+}

--- a/client/V1/Resources/Site.php
+++ b/client/V1/Resources/Site.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Resources;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+
+class Site extends Resource
+{
+    /**
+     * Resource type as per the API.
+     *
+     * @var string
+     */
+    protected $type = 'sites';
+
+    /**
+     * Attributes provided by the API and default values.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'domain' => null,
+    ];
+}

--- a/client/V1/Resources/User.php
+++ b/client/V1/Resources/User.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\V1\Resources;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+
+class User extends Resource
+{
+    /**
+     * Resource type as per the API.
+     *
+     * @var string
+     */
+    protected $type = 'users';
+
+    /**
+     * Attributes provided by the API and default values.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'name'  => null,
+        'email' => null,
+    ];
+
+    /**
+     * Relationships to other Resources.
+     *
+     * @var array
+     */
+    protected $relationships = [
+        'notifications' => [Notification::class, self::RELATIONSHIP_MANY],
+    ];
+}

--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,33 @@
 {
     "require": {
-        "hydrawiki/reverb-client": "^0.1",
+        "tightenco/collect": "^v8.83.25",
+        "guzzlehttp/psr7": "^1.4",
+        "woohoolabs/yang": "^2.0",
+        "php-http/httplug": "^2.0",
+        "php-http/message-factory": "^1.0",
         "php-http/discovery": "^1.6",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/message": "^1.7"
     },
     "require-dev": {
-        "hydrawiki/hydrawiki-codesniffer": "^1.0",
         "jakub-onderka/php-console-highlighter": "^0.4.0",
         "jakub-onderka/php-parallel-lint": "^1.0",
         "mediawiki/minus-x": "^0.3.2",
         "mockery/mockery": "^1.2",
         "php-mock/php-mock-mockery": "^1.3",
-        "phpunit/phpunit": "^8",
+        "phpunit/phpunit": "^9",
         "seld/jsonlint": "^1.7"
     },
     "autoload": {
         "psr-4": {
+            "Hydrawiki\\Reverb\\Client\\": "client/",
             "Reverb\\": "includes/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "Tests\\": "tests/",
+            "Hydrawiki\\Reverb\\Client\\Tests\\Unit\\": "tests/Client"
         }
     },
     "config": {
@@ -42,7 +47,7 @@
         "fix": [
             "minus-x fix .",
             "phpcbf"
-        ]
+        ],
+        "client-test": "phpunit --testsuite=Client"
     }
-
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,9 @@
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
+        <testsuite name="Client">
+            <directory suffix="Test.php">./tests/Client</directory>
+        </testsuite>
     </testsuites>
     <php>
         <env name="APP_ENV" value="testing"/>

--- a/tests/Client/V1/Api/ApiTest.php
+++ b/tests/Client/V1/Api/ApiTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Api;
+
+use GuzzleHttp\Psr7\Response;
+use Http\Client\HttpClient;
+use Hydrawiki\Reverb\Client\V1\Api\Api;
+use Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse;
+use Hydrawiki\Reverb\Client\V1\Api\MessageFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class ApiTest extends TestCase
+{
+    /**
+     * Create a Mock response.
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->response = $this->createMock(ResponseInterface::class);
+        $this->response->method('getStatusCode')->willReturn(200);
+        $this->response->method('getBody')->willReturn(null);
+    }
+
+    /**
+     * Tests that a GET request is made.
+     */
+    public function testGetRequest(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $httpClient = $this->createMock(HttpClient::class);
+        $messageFactory = $this->createMock(MessageFactory::class);
+
+        $messageFactory->expects($this->once())
+            ->method('createRequest')
+            ->with('GET', 'resources')
+            ->willReturn($request);
+
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($request)
+            ->willReturn($this->response);
+
+        $api = new Api($httpClient, $messageFactory);
+        $response = $api->get('resources');
+
+        $this->assertInstanceOf(JsonApiResponse::class, $response);
+    }
+
+    /**
+     * Tests that a POST request with a body is made.
+     */
+    public function testPostRequestWithBody(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $httpClient = $this->createMock(HttpClient::class);
+        $messageFactory = $this->createMock(MessageFactory::class);
+
+        $messageFactory->expects($this->once())
+            ->method('createRequest')
+            ->with('POST', 'resources', '{"x":"y"}')
+            ->willReturn($request);
+
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($request)
+            ->willReturn($this->response);
+
+        $api = new Api($httpClient, $messageFactory);
+        $response = $api->post('resources', ['x' => 'y']);
+
+        $this->assertInstanceOf(JsonApiResponse::class, $response);
+    }
+
+    /**
+     * Tests that a PATCH request with a body is made.
+     */
+    public function testPatchRequestWithBody(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $httpClient = $this->createMock(HttpClient::class);
+        $messageFactory = $this->createMock(MessageFactory::class);
+
+        $messageFactory->expects($this->once())
+            ->method('createRequest')
+            ->with('PATCH', 'resources', '{"x":"y"}')
+            ->willReturn($request);
+
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($request)
+            ->willReturn($this->response);
+
+        $api = new Api($httpClient, $messageFactory);
+        $response = $api->patch('resources', ['x' => 'y']);
+
+        $this->assertInstanceOf(JsonApiResponse::class, $response);
+    }
+
+    /**
+     * Tests that a DELETE requet is made without a body.
+     */
+    public function testDeleteRequestWithoutBody(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $httpClient = $this->createMock(HttpClient::class);
+        $messageFactory = $this->createMock(MessageFactory::class);
+
+        $messageFactory->expects($this->once())
+            ->method('createRequest')
+            ->with('DELETE', 'resources/1')
+            ->willReturn($request);
+
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($request)
+            ->willReturn($this->response);
+
+        $api = new Api($httpClient, $messageFactory);
+
+        $this->assertInstanceOf(JsonApiResponse::class, $api->delete('resources/1'));
+    }
+
+    /**
+     * Tests that a DELETE request is made with a body.
+     */
+    public function testDeleteRequestWithBody(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $httpClient = $this->createMock(HttpClient::class);
+        $messageFactory = $this->createMock(MessageFactory::class);
+
+        $messageFactory->expects($this->once())
+            ->method('createRequest')
+            ->with('DELETE', 'resources/1/relationships/relations', '{"x":"y"}')
+            ->willReturn($request);
+
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($request)
+            ->willReturn($this->response);
+
+        $api = new Api($httpClient, $messageFactory);
+        $response = $api->delete('resources/1/relationships/relations', ['x' => 'y']);
+
+        $this->assertInstanceOf(JsonApiResponse::class, $response);
+    }
+}

--- a/tests/Client/V1/Api/DocumentTest.php
+++ b/tests/Client/V1/Api/DocumentTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Api;
+
+use Hydrawiki\Reverb\Client\V1\Api\Document;
+use Hydrawiki\Reverb\Client\V1\Api\ResourceObject;
+use PHPUnit\Framework\TestCase;
+use WoohooLabs\Yang\JsonApi\Schema\Document as YangDocument;
+
+class DocumentTest extends TestCase
+{
+    /**
+     * Tests that `allResources()` provides both primary resources and included
+     * resources.
+     */
+    public function testDocumentProvidesPrimaryAndIncludedResources(): void
+    {
+        $yangDocument = YangDocument::fromArray([
+            'data' => [
+                [
+                    'type' => 'resources',
+                    'id'   => '1',
+                ],
+                [
+                    'type' => 'resources',
+                    'id'   => '2',
+                ],
+            ],
+            'included' => [
+                [
+                    'type' => 'resources',
+                    'id'   => '3',
+                ],
+                [
+                    'type' => 'resources',
+                    'id'   => '4',
+                ],
+            ],
+        ]);
+
+        $document = new Document($yangDocument);
+
+        $this->assertCount(4, $document->allResources());
+    }
+
+    /**
+     * Tests that when a Document contains many primary resources that
+     * `primaryResources()` returns all of them.
+     */
+    public function testDocumentProvidesPrimaryResources(): void
+    {
+        $yangDocument = YangDocument::fromArray([
+            'data' => [
+                [
+                    'type' => 'resources',
+                    'id'   => '1',
+                ],
+                [
+                    'type' => 'resources',
+                    'id'   => '2',
+                ],
+            ],
+            'included' => [
+                [
+                    'type' => 'resources',
+                    'id'   => '3',
+                ],
+                [
+                    'type' => 'resources',
+                    'id'   => '4',
+                ],
+            ],
+        ]);
+
+        $document = new Document($yangDocument);
+
+        $this->assertCount(2, $document->primaryResources());
+    }
+
+    /**
+     * Tests that when a Document contains a single primary resource that
+     * the resource is provided.
+     */
+    public function testDocumentProvidesPrimaryResource(): void
+    {
+        $yangDocument = YangDocument::fromArray([
+            'data' => [
+                'type' => 'resources',
+                'id'   => '1',
+            ],
+        ]);
+
+        $document = new Document($yangDocument);
+
+        $this->assertCount(1, $document->primaryResources());
+    }
+
+    /**
+     * Tests that Yang ResourceObjects are wrapped in our own ResourceObject
+     * class.
+     */
+    public function testResourcesAreWrappedAsResourceObjects(): void
+    {
+        $yangDocument = YangDocument::fromArray([
+            'data' => [
+                [
+                    'type' => 'resources',
+                    'id'   => '1',
+                ],
+            ],
+            'included' => [
+                [
+                    'type' => 'resources',
+                    'id'   => '3',
+                ],
+            ],
+        ]);
+
+        $document = new Document($yangDocument);
+
+        $this->assertInstanceOf(ResourceObject::class, $document->primaryResources()->first());
+        $this->assertInstanceOf(ResourceObject::class, $document->includedResources()->first());
+    }
+
+    /**
+     * Tests that a Document is correctly labelled as having one Primary
+     * resource.
+     */
+    public function testIsOnePrimaryResource(): void
+    {
+        $yangDocument = YangDocument::fromArray([
+            'data' => [
+                'type' => 'resources',
+                'id'   => '1',
+            ],
+        ]);
+
+        $document = new Document($yangDocument);
+
+        $this->assertTrue($document->isOne());
+        $this->assertFalse($document->isMany());
+    }
+
+    /**
+     * Tests that a Document is correctly labelled as having many Primary
+     * resources.
+     */
+    public function testIsManyPrimaryResource(): void
+    {
+        $yangDocument = YangDocument::fromArray([
+            'data' => [
+                [
+                    'type' => 'resources',
+                    'id'   => '1',
+                ],
+            ],
+        ]);
+
+        $document = new Document($yangDocument);
+
+        $this->assertTrue($document->isMany());
+        $this->assertFalse($document->isOne());
+    }
+
+    /**
+     * Tests that when a Document has meta it is available on the Resources
+     * Collection.
+     */
+    public function testResourcesFromDocumentOfManyHaveMeta(): void
+    {
+        $yangDocument = YangDocument::fromArray([
+            'data' => [
+                [
+                    'type' => 'resources',
+                    'id'   => '1',
+                ],
+            ],
+            'meta' => [
+                'x' => 'y',
+                '1' => '2',
+            ],
+        ]);
+
+        $document = new Document($yangDocument);
+
+        $expected = ['x' => 'y', '1' => '2'];
+        $meta = $document->primaryResources()->meta();
+
+        $this->assertEquals($expected, $meta);
+    }
+}

--- a/tests/Client/V1/Api/JsonApiResponseTest.php
+++ b/tests/Client/V1/Api/JsonApiResponseTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Api;
+
+use Hydrawiki\Reverb\Client\V1\Api\Document;
+use Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse;
+use Hydrawiki\Reverb\Client\V1\Exceptions\DocumentMissing;
+use PHPUnit\Framework\TestCase;
+
+class JsonApiResponseTest extends TestCase
+{
+    /**
+     * Tests that an index is successful if the status code is 200 and the
+     * document contains many primary resources.
+     */
+    public function testIsSuccessfulIndex(): void
+    {
+        $document = $this->createMock(Document::class);
+        $document->method('isMany')->willReturn(true);
+
+        $response = new JsonApiResponse(200, $document);
+        $this->assertTrue($response->isSuccessfulIndex());
+    }
+
+    /**
+     * Tests that a read is successful if the status codei s 200 and the
+     * document has one primary resource.
+     */
+    public function testIsSuccessfulRead(): void
+    {
+        $document = $this->createMock(Document::class);
+        $document->method('isOne')->willReturn(true);
+
+        $response = new JsonApiResponse(200, $document);
+        $this->assertTrue($response->isSuccessfulRead());
+    }
+
+    /**
+     * Tests that when a Document was not a part of the Response that an
+     * exception is thrown when trying to access the document.
+     */
+    public function testExceptionWhenDocumentIsNotAvailable(): void
+    {
+        $response = new JsonApiResponse(200, null);
+
+        $this->expectException(DocumentMissing::class);
+
+        $response->document();
+    }
+}

--- a/tests/Client/V1/Api/MessageFactoryTest.php
+++ b/tests/Client/V1/Api/MessageFactoryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Api;
+
+use Http\Message\MessageFactory as HttpMessageFactory;
+use Hydrawiki\Reverb\Client\V1\Api\Document;
+use Hydrawiki\Reverb\Client\V1\Api\MessageFactory;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ApiResponseInvalid;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class MessageFactoryTest extends TestCase
+{
+    /**
+     * Tests that the request is created with the method, URI (including
+     * endpoint) and body.
+     */
+    public function testRequestHasAllValues(): void
+    {
+        $httpMessageFactory = $this->createMock(HttpMessageFactory::class);
+        $httpMessageFactory->expects($this->once())
+            ->method('createRequest')
+            ->with(
+                'POST',
+                'https://www.example.com/api/v1/resources/1/relationships/relations',
+                [
+                    'Accept'       => 'application/vnd.api+json',
+                    'Content-Type' => 'application/vnd.api+json',
+                ],
+                '{"x":"y"}'
+            )
+            ->willReturn($this->createMock(RequestInterface::class));
+
+        $messageFactory = new MessageFactory(
+            $httpMessageFactory,
+            'https://www.example.com/api/v1'
+        );
+
+        $messageFactory->createRequest(
+            'POST',
+            'resources/1/relationships/relations',
+            '{"x":"y"}'
+        );
+    }
+
+    /**
+     * Tests that a Response is created without a document when the body of the
+     * response is empty.
+     */
+    public function testResponseCreatedWithoutDocument(): void
+    {
+        $messageFactory = new MessageFactory(
+            $this->createMock(HttpMessageFactory::class),
+            'https://www.example.com/api/v1'
+        );
+
+        $response = $messageFactory->createResponse(204, '');
+
+        $this->assertEquals(204, $response->statusCode());
+        $this->assertFalse($response->hasDocument());
+    }
+
+    /**
+     * Tests that a Response is created with a Document when there is a body.
+     */
+    public function testResponseCreatedWithDocument(): void
+    {
+        $messageFactory = new MessageFactory(
+            $this->createMock(HttpMessageFactory::class),
+            'https://www.example.com/api/v1'
+        );
+
+        $response = $messageFactory->createResponse(200, '{"data":[]}');
+
+        $this->assertInstanceOf(Document::class, $response->document());
+    }
+
+    /**
+     * Tests that when the response contains a body but is not valid JSON that
+     * an exception is thrown.
+     */
+    public function testResponseWithInvalidJsonThrowsException(): void
+    {
+        $messageFactory = new MessageFactory(
+            $this->createMock(HttpMessageFactory::class),
+            'https://www.example.com/api/v1'
+        );
+
+        $this->expectException(ApiResponseInvalid::class);
+
+        $messageFactory->createResponse(200, 'invalid-json');
+    }
+}

--- a/tests/Client/V1/Api/ResourceObjectTest.php
+++ b/tests/Client/V1/Api/ResourceObjectTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Api;
+
+use Hydrawiki\Reverb\Client\V1\Api\Resource;
+use Hydrawiki\Reverb\Client\V1\Api\ResourceObject;
+use PHPUnit\Framework\TestCase;
+use Tightenco\Collect\Support\Collection;
+use WoohooLabs\Yang\JsonApi\Schema\Link\RelationshipLinks as YangRelationshipLinks;
+use WoohooLabs\Yang\JsonApi\Schema\Link\ResourceLinks as YangResourceLinks;
+use WoohooLabs\Yang\JsonApi\Schema\Relationship as YangRelationship;
+use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject as YangResourceObject;
+use WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObjects as YangResourceObjects;
+
+class ResourceObjectTest extends TestCase
+{
+    /**
+     * Tests that a Resource Object returns the expected properties taken from
+     * the WoohooLabs\Yang\JsonApi\Schema\Resource\ResourceObject.
+     */
+    public function testResourceObjectProperties(): void
+    {
+        $yangResourceObject = new YangResourceObject(
+            'examples',
+            '1',
+            ['x' => 'y'],
+            new YangResourceLinks([]),
+            ['name' => 'Example'],
+            []
+        );
+
+        $resourceObject = new ResourceObject($yangResourceObject);
+
+        $this->assertEquals('examples', $resourceObject->type());
+        $this->assertEquals('1', $resourceObject->id());
+        $this->assertEquals('examples.1', $resourceObject->key());
+        $this->assertEquals(['name' => 'Example'], $resourceObject->attributes());
+        $this->assertEquals(['x' => 'y'], $resourceObject->meta());
+    }
+
+    /**
+     * Tests that Resource relations are hydrated from the supplied resources.
+     */
+    public function testResourceObjectRelationsFormat(): void
+    {
+        $childrenRelationship = new YangRelationship(
+            'children',
+            [],
+            new YangRelationshipLinks([]),
+            [['type' => 'examples', 'id' => '1'], ['type' => 'examples', 'id' => '2']],
+            new YangResourceObjects([], [], true),
+            true
+        );
+
+        $parentRelationship = new YangRelationship(
+            'parent',
+            [],
+            new YangRelationshipLinks([]),
+            [['type' => 'examples', 'id' => '1']],
+            new YangResourceObjects([], [], true),
+            true
+        );
+
+        $yangResourceObject = new YangResourceObject(
+            'examples',
+            '1',
+            [],
+            new YangResourceLinks([]),
+            [],
+            [$childrenRelationship, $parentRelationship]
+        );
+
+        $object = new ResourceObject($yangResourceObject);
+
+        $expected = new Collection([
+            'parent' => [
+                ['type' => 'examples', 'id' => '1'],
+            ],
+            'children' => [
+                ['type' => 'examples', 'id' => '1'],
+                ['type' => 'examples', 'id' => '2'],
+            ],
+        ]);
+
+        $this->assertEquals($expected, $object->relations());
+    }
+}

--- a/tests/Client/V1/ClientFactoryTest.php
+++ b/tests/Client/V1/ClientFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1;
+
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
+use Hydrawiki\Reverb\Client\V1\Client;
+use Hydrawiki\Reverb\Client\V1\ClientFactory;
+use PHPUnit\Framework\TestCase;
+
+class ClientFactoryTest extends TestCase
+{
+    /**
+     * Tests that a Client is created by the Client Factory.
+     */
+    public function testClientFactoryMakesClient(): void
+    {
+        $factory = new ClientFactory();
+
+        $client = $factory->make(
+            $this->createMock(HttpClient::class),
+            $this->createMock(MessageFactory::class),
+            'https://www.example.com/api/v1',
+			'watkey'
+        );
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+}

--- a/tests/Client/V1/ClientTest.php
+++ b/tests/Client/V1/ClientTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1;
+
+use Hydrawiki\Reverb\Client\V1\Client;
+use Hydrawiki\Reverb\Client\V1\Api\Api;
+use Hydrawiki\Reverb\Client\V1\Api\Document;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ApiRequestUnsuccessful;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ClientResourceCall;
+use Hydrawiki\Reverb\Client\V1\Hydrators\Hydrator;
+use Hydrawiki\Reverb\Client\V1\Api\JsonApiResponse;
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use Hydrawiki\Reverb\Client\V1\Collections\Resources;
+use Hydrawiki\Reverb\Client\Tests\Unit\V1\Mocks\MockResource;
+use PHPUnit\Framework\TestCase;
+use Tightenco\Collect\Support\Collection;
+
+class ClientTest extends TestCase
+{
+    /**
+     * Tests that when a resource call is made with multiple parameters an
+     * exception is thrown.
+     */
+    public function testTooManyResourceParametersThrowsException(): void
+    {
+        $client = new Client($this->createMock(Api::class), $this->createMock(Hydrator::class));
+
+        $this->expectException(ClientResourceCall::class);
+
+        $client->resources(1, 2);
+    }
+
+    /**
+     * Tests that when a resource call is made with a non-Resource object that
+     * an exception is thrown.
+     */
+    public function testNonResourceObjectThrowsException(): void
+    {
+        $client = new Client($this->createMock(Api::class), $this->createMock(Hydrator::class));
+
+        $this->expectException(ClientResourceCall::class);
+
+        $client->resources($client);
+    }
+
+    /**
+     * Tests that the client retrieves an index of Resources.
+     */
+    public function testClientIndexesResources(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulIndex')->willReturn(true);
+        $response->method('document')->willReturn($document);
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->expects($this->once())
+            ->method('hydrate')
+            ->with($document)
+            ->willReturn(new Resources());
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('get')
+            ->with('resources')
+            ->willReturn($response);
+
+        $client = new Client($api, $hydrator);
+        $client->resources()->all();
+    }
+
+    /**
+     * Tests that when an Index is unsuccessful that an Exception is thrown.
+     */
+    public function testUnsuccessfulIndexThrowsException(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulIndex')->willReturn(false);
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('get')
+            ->with('resources')
+            ->willReturn($response);
+
+        $client = new Client($api, $this->createMock(Hydrator::class));
+
+        $this->expectException(ApiRequestUnsuccessful::class);
+
+        $client->resources()->all();
+    }
+
+    /**
+     * Tests that nested resources can be accessed through a fluent interface.
+     */
+    public function testNestedRelationshipRequests(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulIndex')->willReturn(true);
+        $response->method('document')->willReturn($document);
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->expects($this->once())
+            ->method('hydrate')
+            ->with($document)
+            ->willReturn(new Resources());
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('get')
+            ->with('resources/1/children')
+            ->willReturn($response);
+
+        $resource = $this->createMock(Resource::class);
+        $resource->method('id')->willReturn('1');
+
+        $client = new Client($api, $hydrator);
+        $client->resources($resource)->children()->all();
+    }
+
+    /**
+     * Tests that a single resource is retrieved by its ID.
+     */
+    public function testClientRequestsSingleResource(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulRead')->willReturn(true);
+        $response->method('document')->willReturn($document);
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->expects($this->once())
+            ->method('hydrate')
+            ->with($document)
+            ->willReturn(
+                new class() extends Resource {
+                }
+            );
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('get')
+            ->with('resources/1')
+            ->willReturn($response);
+
+        $client = new Client($api, $hydrator);
+        $client->resources()->find('1');
+    }
+
+    /**
+     * Tests that the client's state is reset between requests.
+     */
+    public function testSubsequentRequestsHaveFreshState(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulIndex')->willReturn(true);
+        $response->method('document')->willReturn($document);
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->method('hydrate')->willReturn(new Resources());
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->exactly(2))
+            ->method('get')
+            ->with('resources')
+            ->willReturn($response);
+
+        $client = new Client($api, $hydrator);
+
+        $client->resources()->all();
+        $client->resources()->all();
+    }
+
+    /**
+     * Tests that one or more resources can be included using the client.
+     */
+    public function testClientIncludes(): void
+    {
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulIndex')->willReturn(true);
+        $response->method('document')->willReturn($this->createMock(Document::class));
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->method('hydrate')->willReturn(new Resources());
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('get')
+            ->with('resources?include=relation1%2Crelation2')
+            ->willReturn($response);
+
+        $client = new Client($api, $hydrator);
+
+        $client->resources()->include('relation1', 'relation2')->all();
+    }
+
+    /**
+     * Tests that a request is made to the JSON:API to create a new Resource.
+     */
+    public function testClientCreatesResource(): void
+    {
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulCreate')->willReturn(true);
+        $response->method('document')->willReturn($this->createMock(Document::class));
+
+        $data = [
+            'data' => [
+                'type' => 'mocks',
+                'attributes' => [
+                    'name' => 'John Doe',
+                ],
+            ],
+        ];
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('post')
+            ->with('resources', $data)
+            ->willReturn($response);
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->expects($this->once())
+            ->method('hydrate')
+            ->willReturn(
+                new class extends Resource {}
+            );
+
+        $resource = new MockResource([
+            'name' => 'John Doe',
+        ]);
+
+        $client = new Client($api, $hydrator);
+        $client->resources()->create($resource);
+    }
+
+    /**
+     * Tests that when a resource is updated a request is made to the JSON:API
+     * service.
+     */
+    public function testClientUpdatesResource(): void
+    {
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulUpdate')->willReturn(true);
+
+        $data = [
+            'data' => [
+                'type' => 'mocks',
+                'id' => '1',
+                'attributes' => [
+                    'name' => 'John Doe',
+                ],
+            ],
+        ];
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('patch')
+            ->with('mocks/1', $data)
+            ->willReturn($response);
+
+        $hydrator = $this->createMock(Hydrator::class);
+
+        $resource = new MockResource([
+            'name' => 'John Doe',
+        ]);
+        $resource->setId('1');
+
+        $client = new Client($api, $hydrator);
+        $result = $client->update($resource);
+
+        $this->assertSame($result, $resource);
+    }
+
+    /**
+     * Tests that page[limit] and page[offset] are included when `page()` is
+     * used.
+     */
+    public function testRequestIsPaginated(): void
+    {
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulIndex')->willReturn(true);
+        $response->method('document')->willReturn($this->createMock(Document::class));
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->method('hydrate')->willReturn(new Resources());
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('get')
+            ->with('resources?page%5Blimit%5D=10&page%5Boffset%5D=100')
+            ->willReturn($response);
+
+        $client = new Client($api, $hydrator);
+
+        $client->resources()->page(10, 100)->all();
+    }
+
+    /**
+     * Tests that filter parameters are included when filtering.
+     */
+    public function testRequestIsFiltered(): void
+    {
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulIndex')->willReturn(true);
+        $response->method('document')->willReturn($this->createMock(Document::class));
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->method('hydrate')->willReturn(new Resources());
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('get')
+            ->with('resources?filter%5Ba%5D=1&filter%5Bb%5D=2')
+            ->willReturn($response);
+
+        $client = new Client($api, $hydrator);
+
+        $client->resources()->filter(['a' => '1', 'b' => '2'])->all();
+    }
+
+    /**
+     * Tests that when a resource has a hyphenated name that it can be accessed
+     * using an underscore in place of any hyphens.
+     */
+    public function testResourceNamesWithDashAreSupported(): void
+    {
+        $document = $this->createMock(Document::class);
+
+        $response = $this->createMock(JsonApiResponse::class);
+        $response->method('isSuccessfulIndex')->willReturn(true);
+        $response->method('document')->willReturn($document);
+
+        $hydrator = $this->createMock(Hydrator::class);
+        $hydrator->expects($this->once())
+            ->method('hydrate')
+            ->with($document)
+            ->willReturn(new Resources());
+
+        $api = $this->createMock(Api::class);
+        $api->expects($this->once())
+            ->method('get')
+            ->with('example-resources')
+            ->willReturn($response);
+
+        $client = new Client($api, $hydrator);
+        $client->example_resources()->all();
+    }
+}

--- a/tests/Client/V1/Collections/ResourcesTest.php
+++ b/tests/Client/V1/Collections/ResourcesTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Collections;
+
+use Hydrawiki\Reverb\Client\V1\Collections\Resources;
+use PHPUnit\Framework\TestCase;
+
+class ResourcesTest extends TestCase
+{
+    /**
+     * Tests that meta data is retained after mapping.
+     */
+    public function testMetaIsRetainedAfterMap(): void
+    {
+        $resources = new Resources;
+        $resources->setMeta(['x' => 'y']);
+
+        $mapped = $resources->map(function ($resource) {
+            return $resource;
+        });
+
+        $this->assertSame(['x' => 'y'], $mapped->meta());
+    }
+}

--- a/tests/Client/V1/Hydrators/ResourceFactoryTest.php
+++ b/tests/Client/V1/Hydrators/ResourceFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Hydrators;
+
+use Hydrawiki\Reverb\Client\V1\Exceptions\ResourceTypeUnmapped;
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use Hydrawiki\Reverb\Client\V1\Hydrators\ResourceFactory;
+use PHPUnit\Framework\TestCase;
+
+class ResourceFactoryTest extends TestCase
+{
+    /**
+     * Tests that a Resource is created from a resource type.
+     */
+    public function testResourceIsMadeFromType(): void
+    {
+        $resourceType = new class() extends Resource {
+        };
+
+        $factory = new ResourceFactory([
+            'examples' => get_class($resourceType),
+        ]);
+
+        $resource = $factory->make('examples');
+
+        $this->assertInstanceOf(get_class($resourceType), $resource);
+    }
+
+    /**
+     * Tests that when a resource type has not been mapped to a Resource that an
+     * exception is thrown.
+     */
+    public function testUnmappedResourceTypeThrowsException(): void
+    {
+        $factory = new ResourceFactory([]);
+
+        $this->expectException(ResourceTypeUnmapped::class);
+
+        $factory->make('undefined');
+    }
+}

--- a/tests/Client/V1/Hydrators/ResourceHydratorTest.php
+++ b/tests/Client/V1/Hydrators/ResourceHydratorTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Hydrators;
+
+use Hydrawiki\Reverb\Client\V1\Api\Document;
+use Hydrawiki\Reverb\Client\V1\Api\ResourceObject;
+use Hydrawiki\Reverb\Client\V1\Hydrators\ResourceHydrator;
+use Hydrawiki\Reverb\Client\V1\Hydrators\ResourceFactory;
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use Hydrawiki\Reverb\Client\V1\Collections\Resources;
+use PHPUnit\Framework\TestCase;
+use Tightenco\Collect\Support\Collection;
+
+class ResourceHydratorTest extends TestCase
+{
+    /**
+     * Tests that when a Document is a single primary resource document that a
+     * single hydrated Resource is returned.
+     */
+    public function testHydratorReturnsSinglePrimaryResource(): void
+    {
+        $primaryResource = $this->createMock(Resource::class);
+
+        $resourceObject = $this->createMock(ResourceObject::class);
+        $resourceObject->method('relations')->willReturn(new Resources());
+        $resourceObject->method('key')->willReturn('resources.1');
+
+        $document = $this->createMock(Document::class);
+        $document->method('allResources')->willReturn(new Resources([
+            $resourceObject,
+        ]));
+
+        $document->method('primaryResources')->willReturn(new Resources([
+            $resourceObject,
+        ]));
+
+        $resourceFactory = $this->createMock(ResourceFactory::class);
+        $resourceFactory->method('make')->willReturn($primaryResource);
+
+        $hydrator = new ResourceHydrator($resourceFactory);
+
+        $document->method('isOne')->willReturn(true);
+
+        $this->assertEquals($primaryResource, $hydrator->hydrate($document));
+    }
+
+    /**
+     * Tests that when a document has many primary resources (even if the
+     * document only has one of many) that a Collection of resources is
+     * returned.
+     */
+    public function testHydratorReturnsCollectionForManyDocument(): void
+    {
+        $primaryResource = $this->createMock(Resource::class);
+
+        $resourceObject = $this->createMock(ResourceObject::class);
+        $resourceObject->method('relations')->willReturn(new Resources());
+        $resourceObject->method('key')->willReturn('resources.1');
+
+        $document = $this->createMock(Document::class);
+        $document->method('allResources')->willReturn(new Resources([
+            $resourceObject,
+        ]));
+
+        $document->method('primaryResources')->willReturn(new Resources([
+            $resourceObject,
+        ]));
+
+        $resourceFactory = $this->createMock(ResourceFactory::class);
+        $resourceFactory->method('make')->willReturn($primaryResource);
+
+        $hydrator = new ResourceHydrator($resourceFactory);
+
+        $document->method('isOne')->willReturn(false);
+
+        $this->assertEquals(
+            (new Resources())->wrap($primaryResource),
+            $hydrator->hydrate($document)
+        );
+    }
+
+    /**
+     * Tests that the Resource's relations are hydrated with the relation's
+     * Resource.
+     */
+    public function testRelationsAreHydrated(): void
+    {
+        $resource1 = $this->createMock(Resource::class);
+        $resource2 = $this->createMock(Resource::class);
+
+        $resourceObject1 = $this->createMock(ResourceObject::class);
+        $resourceObject1->method('key')->willReturn('resources.1');
+        $resourceObject1->method('relations')->willReturn(new Resources([
+            'children' => [
+                ['type' => 'resources', 'id' => '1'],
+                ['type' => 'resources', 'id' => '2'],
+            ],
+            'parent' => [
+                ['type' => 'resources', 'id' => '1'],
+            ],
+        ]));
+
+        $resourceObject2 = $this->createMock(ResourceObject::class);
+        $resourceObject2->method('key')->willReturn('resources.2');
+        $resourceObject2->method('relations')->willReturn(new Resources());
+
+        $document = $this->createMock(Document::class);
+        $document->method('allResources')->willReturn(new Resources([
+            $resourceObject1,
+            $resourceObject2,
+        ]));
+
+        $resourceFactory = $this->createMock(ResourceFactory::class);
+		$resourceFactory->expects($this->any())->method('make')
+			->willReturnOnConsecutiveCalls($resource1, $resource2);
+
+        $resource1->expects($this->once())
+            ->method('setId')
+            ->willReturn($resource1);
+
+        $resource1->expects($this->once())
+            ->method('setAttributes')
+            ->willReturn($resource1);
+
+        $resource1->expects($this->once())
+            ->method('setMeta')
+            ->willReturn($resource1);
+
+        $resource1->expects($this->once())
+            ->method('setRelations')
+            ->with([
+                'children' => [
+                    $resource1,
+                    $resource2,
+                ],
+                'parent' => [
+                    $resource1,
+                ],
+            ])
+            ->willReturn($resource1);
+
+        (new ResourceHydrator($resourceFactory))->hydrate($document);
+    }
+}

--- a/tests/Client/V1/Mocks/MockResource.php
+++ b/tests/Client/V1/Mocks/MockResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Mocks;
+
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+
+class MockResource extends Resource
+{
+    /**
+     * Resource type as per the API.
+     *
+     * @var string
+     */
+    protected $type = 'mocks';
+
+    /**
+     * Attributes provided by the API and default values.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'name' => null,
+    ];
+
+    /**
+     * Relationships to other Resources.
+     *
+     * @var array
+     */
+    protected $relationships = [
+        'mocks' => [MockResource::class, self::RELATIONSHIP_MANY],
+        'mock'  => [MockResource::class, self::RELATIONSHIP_ONE],
+    ];
+}

--- a/tests/Client/V1/Resources/ResourceTest.php
+++ b/tests/Client/V1/Resources/ResourceTest.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hydrawiki\Reverb\Client\Tests\Unit\V1\Resources;
+
+use Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAlreadyPopulated;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ResourceAttributeUndefined;
+use Hydrawiki\Reverb\Client\V1\Exceptions\ResourceRelationshipUndefined;
+use Hydrawiki\Reverb\Client\V1\Resources\Resource;
+use Hydrawiki\Reverb\Client\Tests\Unit\V1\Mocks\MockResource;
+use PHPUnit\Framework\TestCase;
+use Tightenco\Collect\Support\Collection;
+
+class ResourceTest extends TestCase
+{
+    /**
+     * Tests that defined attributes have their values populated from the
+     * values passed in to a Resource.
+     */
+    public function testResourceAttributeValuesArePopulated(): void
+    {
+        $values = [
+            'defined' => 'Example',
+        ];
+
+        $resource = new class($values) extends Resource {
+            protected $attributes = [
+                'defined' => null,
+            ];
+        };
+
+        $this->assertSame('Example', $resource->defined);
+    }
+
+    /**
+     * Tests that metadata is added to a Resource.
+     */
+    public function testResourceMetaDataIsProvided(): void
+    {
+        $resource = new class() extends Resource {
+        };
+        $resource->setMeta([
+            'x' => 'y',
+        ]);
+
+        $this->assertSame(['x' => 'y'], $resource->meta());
+        $this->assertSame('y', $resource->meta('x'));
+    }
+
+    /**
+     * Tests that attributes are populated using the `setAttributes` method
+     * after the Resource has been created.
+     */
+    public function testAttributesArePopulatedAfterCreation(): void
+    {
+        $resource = new class() extends Resource {
+            protected $attributes = [
+                'name' => null,
+            ];
+        };
+
+        $resource->setAttributes(['name' => 'Example']);
+        $this->assertEquals('Example', $resource->name);
+    }
+
+    /**
+     * Tests that attributes cannot be set if the attributes were given values
+     * through the Resource constructor -- a developer should use `update` to
+     * change attributes.
+     */
+    public function testAttributesCannotBePopulatedIfPopulatedDuringCreation(): void
+    {
+        $attributes = [
+            'name' => 'Example',
+        ];
+
+        $resource = new class($attributes) extends Resource {
+            protected $attributes = [
+                'name' => null,
+            ];
+        };
+
+        $this->expectException(ResourceAlreadyPopulated::class);
+
+        $resource->setAttributes($attributes);
+    }
+
+    /**
+     * Tests that attributes cannot be populated if they have already been
+     * populated.
+     */
+    public function testAttributesCannotBePopulatedMoreThanOnce(): void
+    {
+        $resource = new class() extends Resource {
+            protected $attributes = [
+                'name' => null,
+            ];
+        };
+
+        $this->expectException(\Exception::class);
+
+        $resource->setAttributes(['name' => 'Example']);
+        $resource->setAttributes(['name' => 'Example']);
+    }
+
+    /**
+     * Tests that when an attribute has a default value the default value is
+     * used when no value is provided.
+     */
+    public function testResourceAttributeValuesExposeDefaults(): void
+    {
+        $resource = new class() extends Resource {
+            protected $attributes = [
+                'hasDefault' => 'defaultValue',
+            ];
+        };
+
+        $this->assertSame('defaultValue', $resource->hasDefault);
+    }
+
+    /**
+     * Tests that when a value is provided for an undefined attribute that the
+     * value is ignored and not merged into the attributes.
+     */
+    public function testUndefinedAttributesAreNotMerged(): void
+    {
+        $values = [
+            'undefined' => 'Example',
+        ];
+
+        $resource = new class($values) extends Resource {
+            protected $attributes = [
+                'defined' => null,
+            ];
+        };
+
+        $this->expectException(ResourceAttributeUndefined::class);
+
+        $resource->unpermitted;
+    }
+
+    /**
+     * Tests that an attribute can be accessed using a normalized key, where
+     * dashes have been replaced with underscores.
+     */
+    public function testAttributeIsAccessibleWithNormalizedKey(): void
+    {
+        $resource = new class() extends Resource {
+            protected $attributes = [
+                'normalized-key' => 'value',
+            ];
+        };
+
+        $this->assertSame('value', $resource->normalized_key);
+    }
+
+    /**
+     * Tests that attribute values are updated and attributes that have not been
+     * provided remain with their original values.
+     */
+    public function testAttributesAreUpdated(): void
+    {
+        $resource = new class() extends Resource {
+            protected $attributes = [
+                'name'     => 'Initialised Name',
+                'hostname' => 'example.com',
+                'counter'  => 1,
+            ];
+        };
+
+        $resource->update([
+            'name'    => 'Changed Name',
+            'counter' => 2,
+        ]);
+
+        $this->assertSame('Changed Name', $resource->name);
+        $this->assertSame('example.com', $resource->hostname);
+        $this->assertSame(2, $resource->counter);
+    }
+
+    /**
+     * Tests that later updates to an attribute replace earlier, providing a
+     * single value per attribute.
+     */
+    public function testSubsequentAttributeChangesOverwriteEarlier(): void
+    {
+        $resource = new class() extends Resource {
+            protected $attributes = [
+                'name'     => 'Initialised Name',
+                'hostname' => 'example.com',
+            ];
+        };
+
+        $resource->update([
+            'name'     => 'First Changed Name',
+            'hostname' => 'First Hostname Change',
+        ]);
+
+        $resource->update([
+            'name' => 'Second Changed Name',
+        ]);
+
+        $this->assertSame([
+            'name'     => 'Second Changed Name',
+            'hostname' => 'First Hostname Change',
+        ], $resource->attributes());
+    }
+
+    /**
+     * Tests that when an attribute value is changed that it is exposed through
+     * the `changes()` method.
+     */
+    public function testChangedAttributeValuesAreProvidedAsChanges(): void
+    {
+        $resource = new class() extends Resource {
+            protected $attributes = [
+                'name'     => 'Initialised Name',
+                'hostname' => 'example.com',
+            ];
+        };
+
+        $resource->update([
+            'name' => 'Changed Name',
+        ]);
+
+        $this->assertSame(['name' => 'Changed Name'], $resource->changes());
+    }
+
+    /**
+     * Tests that all attribute values and attribute defaults are combined to
+     * produce a full set of attributes.
+     */
+    public function testAllAttributesAreProvidedAsAttributes(): void
+    {
+        $resource = new class() extends Resource {
+            protected $attributes = [
+                'name'     => 'Initialised Name',
+                'hostname' => 'example.com',
+            ];
+        };
+
+        $resource->setAttributes([
+            'hostname' => 'changed.com',
+        ]);
+
+        $this->assertSame([
+            'name'     => 'Initialised Name',
+            'hostname' => 'changed.com',
+        ], $resource->attributes());
+    }
+
+    /**
+     * Tests that the Resource ID is set.
+     */
+    public function testResourceIdIsSet(): void
+    {
+        $resource = new class() extends Resource {
+        };
+        $resource->setId('1');
+
+        $this->assertSame('1', $resource->id());
+    }
+
+    /**
+     * Tests that a resource can have an ID (string) or not have an ID (null).
+     */
+    public function testResourceIdIsOptional(): void
+    {
+        $with = new class() extends Resource {
+        };
+        $with->setId('1');
+
+        $without = new class() extends Resource {
+        };
+
+        $this->assertSame('1', $with->id());
+        $this->assertNull($without->id());
+    }
+
+    /**
+     * Tests that Relations are populated.
+     */
+    public function testRelationsArePopulated(): void
+    {
+        $resource = new class() extends Resource {
+            protected $relationships = [
+                'children' => [Resource::class, self::RELATIONSHIP_MANY],
+                'parent'   => [Resource::class, self::RELATIONSHIP_ONE],
+            ];
+        };
+
+        $relation = new class() extends Resource {
+        };
+
+        $resource->setRelations([
+            'children' => [$relation, $relation, $relation],
+            'parent'   => $relation,
+        ]);
+
+        $this->assertCount(3, $resource->children());
+        $this->assertInstanceOf(Resource::class, $resource->parent());
+    }
+
+    /**
+     * Tests that a toOne relationship returns a single Resource, or null when
+     * no relation has been provided for the relationship.
+     */
+    public function testResourceToOneRelationshipReturnsOne(): void
+    {
+        $relations = [
+            'parent' => new class() extends Resource {
+            },
+        ];
+
+        $resource = new class() extends Resource {
+            protected $relationships = [
+                'parent' => [Resource::class, self::RELATIONSHIP_ONE],
+                'child'  => [Resource::class, self::RELATIONSHIP_ONE],
+            ];
+        };
+
+        $resource->setRelations($relations);
+
+        $this->assertInstanceOf(Resource::class, $resource->parent());
+        $this->assertNull($resource->child());
+    }
+
+    /**
+     * Tests that a toMany relationship returns an array of Resources, or an
+     * empty array when no relation has been provided for the relationship.
+     */
+    public function testResourceToManyRelationshipReturnsMany(): void
+    {
+        $relations = [
+            'children' => [
+                new class() extends Resource {
+                },
+                new class() extends Resource {
+                },
+            ],
+        ];
+
+        $resource = new class() extends Resource {
+            protected $relationships = [
+                'children' => [Resource::class, self::RELATIONSHIP_MANY],
+                'parents'  => [Resource::class, self::RELATIONSHIP_MANY],
+            ];
+        };
+
+        $resource->setRelations($relations);
+
+        $this->assertCount(2, $resource->children());
+        $this->assertEquals(new Collection(), $resource->parents());
+    }
+
+    /**
+     * Tests that an undefined relationship exception is thrown when an attempt
+     * is made to access a relationship that has not been defined.
+     */
+    public function testResourceRelationshipUndefinedThrowsException(): void
+    {
+        $resource = new class() extends Resource {
+        };
+
+        $this->expectException(ResourceRelationshipUndefined::class);
+
+        $resource->undefinedRelationship();
+    }
+
+    /**
+     * Tests that new relations are added to a relationship.
+     */
+    public function testNewRelationsAreAdded(): void
+    {
+        $resource = new class() extends Resource {
+            protected $relationships = [
+                'children' => [Resource::class, self::RELATIONSHIP_MANY],
+                'parent'  => [Resource::class, self::RELATIONSHIP_ONE],
+            ];
+        };
+
+        $parent = new class() extends Resource {
+            protected $type = 'parent';
+        };
+
+        $child  = new class() extends Resource {
+            protected $type = 'child';
+        };
+
+        $resource->add('parent', $parent);
+        $resource->add('children', $child);
+        $resource->add('children', $child, $child);
+
+        $this->assertEquals(new Collection([$child, $child, $child]), $resource->children());
+        $this->assertEquals($parent, $resource->parent());
+    }
+
+    /**
+     * Tests that a Resource's properties are rendered for a JSON:API.
+     */
+    public function testResourceIsRenderedForApi(): void
+    {
+        $resource = new MockResource([
+            'name' => 'John Doe',
+        ]);
+
+        $a = (new MockResource)->setId('a');
+        $b = (new MockResource)->setId('b');
+        $c = (new MockResource)->setId('c');
+
+        $resource->add('mock', $a);
+        $resource->add('mocks', $b, $c);
+
+        $expected = [
+            'data' => [
+                'type' => 'mocks',
+                'attributes' => [
+                    'name' => 'John Doe',
+                ],
+                'relationships' => [
+                    'mock' => [
+                        'data' => ['type' => 'mocks', 'id' => 'a'],
+                    ],
+                    'mocks' => [
+                        ['data' => ['type' => 'mocks', 'id' => 'b']],
+                        ['data' => ['type' => 'mocks', 'id' => 'c']],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $resource->toData());
+    }
+
+    /**
+     * Tests that when a Resource has an ID that the ID is included in the
+     * properties rendered for a JSON:API.
+     */
+    public function testPersistedResourceIsRenderedForApiWithId(): void
+    {
+        $resource = (new MockResource([
+            'name' => 'John Doe',
+        ]))->setId('a');
+
+        $expected = [
+            'data' => [
+                'type' => 'mocks',
+                'id' => 'a',
+                'attributes' => [
+                    'name' => 'John Doe',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $resource->toData());
+    }
+}


### PR DESCRIPTION
We currently use the hydrawiki/reverb-client composer package to provide us a Reverb client, which is still hosted on GitLab and is an useless layer of indirection. This complicates the official upgrade to PHP 8.0 as some of its dependencies refuse to install on PHP 8.0.

So, move the client code and tests to this repo, and add an action that runs client tests. Also remove the hydrawiki codesniffer dependency because it's unmaintained and likewise refuses to install on PHP 8.0.