### PR TITLE
UXFCP-3645 (fix): Removed wrong assets url from notification user_note

### DIFF
--- a/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
+++ b/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
@@ -12,6 +12,9 @@ final class NotificationUserNoteAssetsUrlFixer {
 		if ( !isset( $notification['user_note'] ) ) {
 			return $notification;
 		}
+
+		$notification['user_note'] = $this->replaceNotificationImgAssetUrl($notification['user_note']);
+
 		// replace relative path with full urls, so notifications displayed outside of wiki context
 		// (i.e. fandom.com page) work well
 		$notification['user_note'] = preg_replace(
@@ -21,5 +24,24 @@ final class NotificationUserNoteAssetsUrlFixer {
 		);
 
 		return $notification;
+	}
+
+	private function replaceNotificationImgAssetUrl($userNote): array|string|null
+	{
+		$regex = '/(<img\s+[^>]*?\bsrc=["\'].*?)((?!.*\/extensions-ucp\/mw139\/.*).*|^(?=.*\/extensions-ucp\/v2\/.*$).*|^(?=.*\/extensions-ucp\/[^\/]+\/.*$))/m';
+
+		return preg_replace_callback($regex, function ($matches) {
+			$match = $matches[0];
+
+			if (str_contains($match, '/extensions-ucp/mw139/')) {
+				return $match;
+			} elseif (str_contains($match, '/extensions-ucp/v2/mw139/')) {
+				return str_replace('/extensions-ucp/v2/mw139/', '/extensions-ucp/mw139/', $match);
+			} elseif (str_contains($match, '/extensions-ucp/v2/')) {
+				return str_replace('/extensions-ucp/v2/', '/extensions-ucp/mw139/', $match);
+			} else {
+				return str_replace('/extensions-ucp/', '/extensions-ucp/mw139/', $match);
+			}
+		}, $userNote);
 	}
 }

--- a/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
+++ b/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
@@ -12,13 +12,6 @@ final class NotificationUserNoteAssetsUrlFixer {
 		if ( !isset( $notification['user_note'] ) ) {
 			return $notification;
 		}
-
-		$notification['user_note'] = preg_replace(
-			'/\/extensions-ucp(?!\/v2\/)\//',
-			'/extensions-ucp/v2/',
-			$notification['user_note']
-		);
-
 		// replace relative path with full urls, so notifications displayed outside of wiki context
 		// (i.e. fandom.com page) work well
 		$notification['user_note'] = preg_replace(

--- a/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
+++ b/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
@@ -5,6 +5,12 @@ declare( strict_types=1 );
 namespace Reverb\Fixer;
 
 final class NotificationUserNoteAssetsUrlFixer {
+	private const REGEX =
+		'/(<img\s+[^>]*?\bsrc=["\'].*?)' .
+		'((?!.*\/extensions-ucp\/mw139\/.*).*|' .
+		'^(?=.*\/extensions-ucp\/v2\/.*$).*|' .
+		'^(?=.*\/extensions-ucp\/[^\/]+\/.*$))/m';
+
 	public function __construct( private string $domain ) {
 	}
 
@@ -13,7 +19,7 @@ final class NotificationUserNoteAssetsUrlFixer {
 			return $notification;
 		}
 
-		$notification['user_note'] = $this->replaceNotificationImgAssetUrl($notification['user_note']);
+		$notification['user_note'] = $this->replaceNotificationImgAssetUrl( $notification['user_note'] );
 
 		// replace relative path with full urls, so notifications displayed outside of wiki context
 		// (i.e. fandom.com page) work well
@@ -26,22 +32,19 @@ final class NotificationUserNoteAssetsUrlFixer {
 		return $notification;
 	}
 
-	private function replaceNotificationImgAssetUrl($userNote): array|string|null
-	{
-		$regex = '/(<img\s+[^>]*?\bsrc=["\'].*?)((?!.*\/extensions-ucp\/mw139\/.*).*|^(?=.*\/extensions-ucp\/v2\/.*$).*|^(?=.*\/extensions-ucp\/[^\/]+\/.*$))/m';
-
-		return preg_replace_callback($regex, function ($matches) {
+	private function replaceNotificationImgAssetUrl( $userNote ): array|string|null {
+		return preg_replace_callback( self::REGEX, static function ( $matches ) {
 			$match = $matches[0];
 
-			if (str_contains($match, '/extensions-ucp/mw139/')) {
+			if ( str_contains( $match, '/extensions-ucp/mw139/' ) ) {
 				return $match;
-			} elseif (str_contains($match, '/extensions-ucp/v2/mw139/')) {
-				return str_replace('/extensions-ucp/v2/mw139/', '/extensions-ucp/mw139/', $match);
-			} elseif (str_contains($match, '/extensions-ucp/v2/')) {
-				return str_replace('/extensions-ucp/v2/', '/extensions-ucp/mw139/', $match);
+			} elseif ( str_contains( $match, '/extensions-ucp/v2/mw139/' ) ) {
+				return str_replace( '/extensions-ucp/v2/mw139/', '/extensions-ucp/mw139/', $match );
+			} elseif ( str_contains( $match, '/extensions-ucp/v2/' ) ) {
+				return str_replace( '/extensions-ucp/v2/', '/extensions-ucp/mw139/', $match );
 			} else {
-				return str_replace('/extensions-ucp/', '/extensions-ucp/mw139/', $match);
+				return str_replace( '/extensions-ucp/', '/extensions-ucp/mw139/', $match );
 			}
-		}, $userNote);
+		}, $userNote );
 	}
 }

--- a/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
+++ b/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
@@ -5,36 +5,34 @@ namespace Tests\Unit\Fixer;
 use PHPUnit\Framework\TestCase;
 use Reverb\Fixer\NotificationUserNoteAssetsUrlFixer;
 
-class NotificationUserNoteAssetsUrlFixerTest extends TestCase
-{
+class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 	/**
 	 * @dataProvider cheevosDataProvider
 	 * @param string $input
 	 * @param string $expectedResult
 	 * @return void
 	 */
-	public function testCheevosHasCorrectPath(string $input, string $expectedResult): void
-	{
-		$fixer = new NotificationUserNoteAssetsUrlFixer('fandom.com');
+	public function testCheevosHasCorrectPath( string $input, string $expectedResult ): void {
+		$fixer = new NotificationUserNoteAssetsUrlFixer( 'fandom.com' );
 
 		$notificationInput = [
 			'user_note' => $input
 		];
 
-		$fixedNotification = $fixer->fix($notificationInput);
+		$fixedNotification = $fixer->fix( $notificationInput );
 
-		self::assertSame($expectedResult, $fixedNotification['user_note']);
+		self::assertSame( $expectedResult, $fixedNotification['user_note'] );
 	}
 
-	public function cheevosDataProvider(): array
-	{
+	public function cheevosDataProvider(): array {
 		$fullNotification = '
 			<div class=\'reverb-npn-ach\'>
 				<div class=\'reverb-npn-ach-text\'>
 					<div class=\'reverb-npn-ach-name\'>What do we have here?</div>
 					<div class=\'reverb-npn-ach-description\'>Visit the Achievements Special Page.</div>
 				</div>
-				<div class=\'reverb-npn-ach-points\'>10<img src="/extensions-ucp/Cheevos/images/gp30.png" />
+				<div class=\'reverb-npn-ach-points\'>10
+					<img src="/extensions-ucp/Cheevos/images/gp30.png" />
 				</div>
 			</div>
 		';
@@ -45,7 +43,8 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase
 					<div class=\'reverb-npn-ach-name\'>What do we have here?</div>
 					<div class=\'reverb-npn-ach-description\'>Visit the Achievements Special Page.</div>
 				</div>
-				<div class=\'reverb-npn-ach-points\'>10<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png" />
+				<div class=\'reverb-npn-ach-points\'>10
+					<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png" />
 				</div>
 			</div>
 		';

--- a/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
+++ b/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Fixer;
+
+use PHPUnit\Framework\TestCase;
+use Reverb\Fixer\NotificationUserNoteAssetsUrlFixer;
+
+class NotificationUserNoteAssetsUrlFixerTest extends TestCase
+{
+	/**
+	 * @dataProvider cheevosDataProvider
+	 * @param string $input
+	 * @param string $expectedResult
+	 * @return void
+	 */
+	public function testCheevosHasCorrectPath(string $input, string $expectedResult): void
+	{
+		$fixer = new NotificationUserNoteAssetsUrlFixer('fandom.com');
+
+		$notificationInput = [
+			'user_note' => $input
+		];
+
+		$fixedNotification = $fixer->fix($notificationInput);
+
+		self::assertSame($expectedResult, $fixedNotification['user_note']);
+	}
+
+	public function cheevosDataProvider(): array
+	{
+		$fullNotification = '
+			<div class=\'reverb-npn-ach\'>
+				<div class=\'reverb-npn-ach-text\'>
+					<div class=\'reverb-npn-ach-name\'>What do we have here?</div>
+					<div class=\'reverb-npn-ach-description\'>Visit the Achievements Special Page.</div>
+				</div>
+				<div class=\'reverb-npn-ach-points\'>10<img src="/extensions-ucp/Cheevos/images/gp30.png" />
+				</div>
+			</div>
+		';
+
+		$expectedFullNotification = '
+			<div class=\'reverb-npn-ach\'>
+				<div class=\'reverb-npn-ach-text\'>
+					<div class=\'reverb-npn-ach-name\'>What do we have here?</div>
+					<div class=\'reverb-npn-ach-description\'>Visit the Achievements Special Page.</div>
+				</div>
+				<div class=\'reverb-npn-ach-points\'>10<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png" />
+				</div>
+			</div>
+		';
+
+		return [
+			[
+				'<img src="/extensions-ucp/v2/Cheevos/images/gp30.png"',
+				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+			],
+			[
+				'<img src="/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+			],
+			[
+				'<img src="/extensions-ucp/v2/mw139/Cheevos/images/gp30.png"',
+				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+			],
+			[
+				'<img src="/extensions-ucp/Cheevos/images/gp30.png"',
+				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+			],
+			[
+				'<img src="/extensions-ucp/v2/v2/C/x.png"',
+				'<img src="fandom.com/extensions-ucp/mw139/v2/C/x.png"',
+			],
+			[
+				$fullNotification,
+				$expectedFullNotification,
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Links
[UXFCP-3645](https://fandom.atlassian.net/browse/UXFCP-3645)

## Description
**Why**: Cheevos images are displayed as broken in notifications panel for gamepedia wikis. The Cheevos image URL is with `/v2/` what is wrong. 

**How**: The assets should not have `/v2/` url, so I've removed the fixing pattern in filter

## Who might be interested
UXFCP
## Testing Recommendations
- [ ] Check Notification site for gamepedia wiki `https://[wiki]/wiki/Special:Notifications` the cheevos should be visible 
- [ ] Check Notification box on global nav for gamepedia wiki. The cheevos should be visible

<details><summary>screenshot</summary>
<p>

![Zrzut ekranu 2023-04-21 o 10 00 13](https://user-images.githubusercontent.com/1814271/233592396-40fac19e-8fd6-4269-9ef8-1d3fc6e28e6d.png)

</p>
</details> 
