### PR TITLE
UXFCP-3759 (fix): Fix for empty response data

### DIFF
--- a/src/Notification/NotificationFactory.php
+++ b/src/Notification/NotificationFactory.php
@@ -24,12 +24,12 @@ class NotificationFactory {
 	/** @return Notification[] */
 	public function fromResponse( array $response ): array {
 		$dissmissals = [];
-		foreach ( $response['data'] as $data ) {
+		foreach ( $response['data'] ?? [] as $data ) {
 			$dissmissals[(int)$data['relationships']['notification']['data']['id']] =
 				(int)$data['attributes']['dismissed-at'];
 		}
 		$notifications = [];
-		foreach ( $response['included'] as $data ) {
+		foreach ( $response['included'] ?? [] as $data ) {
 			$id = (int)$data['id'];
 			$notifications[$id] = new Notification(
 				$this->config,


### PR DESCRIPTION
Fix for case when we receive response without  'data' or 'included' node. Included node was seen non existing in certain responses. Added safeguard for data node just in case.

https://fandom.atlassian.net/browse/UXFCP-3759