### PR TITLE
Fix observed TypeError in Reverb

### DIFF
--- a/src/ReverbBroadcastHookHandler.php
+++ b/src/ReverbBroadcastHookHandler.php
@@ -498,7 +498,7 @@ class ReverbBroadcastHookHandler implements
 			$broadcast = $this->notificationBroadcastFactory->new(
 				'article-edit-watch',
 				$editor,
-				$watchingUser,
+				[ $watchingUser ],
 				[
 					'url' => $canonicalUrl,
 					'message' => [


### PR DESCRIPTION
Avoid the following:
```
TypeError from line 26 of /extensions/Reverb/src/Notification/NotificationBroadcastFactory.php: Reverb\Notification\NotificationBroadcastFactory::new(): Argument #3 ($targets) must be of type array, User given, called in /extensions/Reverb/src/ReverbBroadcastHookHandler.php on line 513
	#0 /extensions/Reverb/src/ReverbBroadcastHookHandler.php(513): Reverb\Notification\NotificationBroadcastFactory->new(string, User, User, array)
	#1 /extensions/Reverb/src/ReverbBroadcastHookHandler.php(460): Reverb\ReverbBroadcastHookHandler->sendNotificationsForEdit(User, Title, RecentChange)
	#2 /includes/libs/rdbms/database/Database.php(2501): Reverb\ReverbBroadcastHookHandler->Reverb\{closure}(integer, Wikimedia\Rdbms\DatabaseMysqli)
	#3 /includes/libs/rdbms/loadbalancer/LoadBalancer.php(1869): Wikimedia\Rdbms\Database->runOnTransactionIdleCallbacks(integer, array)
	#4 /includes/libs/rdbms/lbfactory/LBFactory.php(469): Wikimedia\Rdbms\LoadBalancer->runPrimaryTransactionIdleCallbacks(string)
	#5 /includes/libs/rdbms/lbfactory/LBFactory.php(424): Wikimedia\Rdbms\LBFactory->executePostTransactionCallbacks()
	#6 /includes/deferred/DeferredUpdates.php(476): Wikimedia\Rdbms\LBFactory->commitPrimaryChanges(string)
	#7 /includes/deferred/DeferredUpdates.php(399): DeferredUpdates::attemptUpdate(MWCallableUpdate, Fandom\Includes\Database\FandomLoadBalancerFactory)
	#8 /includes/deferred/DeferredUpdates.php(214): DeferredUpdates::run(MWCallableUpdate, Fandom\Includes\Database\FandomLoadBalancerFactory, Monolog\Logger, Fandom\Includes\Util\SalvageableBufferingStatsdDataFactory, MediaWiki\JobQueue\JobQueueGroupFactory, string)
	#9 /includes/deferred/DeferredUpdatesScope.php(267): DeferredUpdates::{closure}(MWCallableUpdate, integer)
	#10 /includes/deferred/DeferredUpdatesScope.php(196): DeferredUpdatesScope->processStageQueue(integer, integer, Closure)
	#11 /includes/deferred/DeferredUpdates.php(235): DeferredUpdatesScope->processUpdates(integer, Closure)
	#12 /includes/MediaWiki.php(1104): DeferredUpdates::doUpdates()
	#13 /includes/MediaWiki.php(838): MediaWiki->restInPeace()
	#14 /includes/MediaWiki.php(587): MediaWiki->doPostOutputShutdown()
	#15 /index.php(50): MediaWiki->run()
	#16 /index.php(46): wfIndexMain()
```