### PR TITLE
PLATFORM-8565 | Remove two-version deployments for prod environments

### DIFF
--- a/resources/css/reverb.specialNotifications.fandomdesktop.css
+++ b/resources/css/reverb.specialNotifications.fandomdesktop.css
@@ -29,8 +29,8 @@
   height: 18px;
   background-color: currentColor;
   background-repeat: no-repeat;
-  -webkit-mask-image: url(/resources-ucp/v2/dist/svg/wds-icons-controls-small.svg);
-  mask-image: url(/resources-ucp/v2/dist/svg/wds-icons-controls-small.svg);
+  -webkit-mask-image: url(/resources-ucp/mw139/dist/svg/wds-icons-controls-small.svg);
+  mask-image: url(/resources-ucp/mw139/dist/svg/wds-icons-controls-small.svg);
 }
 .reverb-filter-row {
   padding: 12px 0;
@@ -60,14 +60,14 @@
 .reverb-filter-checkbox--unchecked {
   background-color: currentColor;
   background-repeat: no-repeat;
-  -webkit-mask-image: url(/resources-ucp/v2/dist/svg/wds-icons-checkbox-empty-small.svg);
-  mask-image: url(/resources-ucp/v2/dist/svg/wds-icons-checkbox-empty-small.svg);
+  -webkit-mask-image: url(/resources-ucp/mw139/dist/svg/wds-icons-checkbox-empty-small.svg);
+  mask-image: url(/resources-ucp/mw139/dist/svg/wds-icons-checkbox-empty-small.svg);
 }
 .reverb-filter-checkbox--checked {
   background-color: var(--theme-link-color);
   background-repeat: no-repeat;
-  -webkit-mask-image: url(/resources-ucp/v2/dist/svg/wds-icons-checkbox-small.svg);
-  mask-image: url(/resources-ucp/v2/dist/svg/wds-icons-checkbox-small.svg);
+  -webkit-mask-image: url(/resources-ucp/mw139/dist/svg/wds-icons-checkbox-small.svg);
+  mask-image: url(/resources-ucp/mw139/dist/svg/wds-icons-checkbox-small.svg);
 }
 
 .reverb-button-bar {
@@ -192,31 +192,31 @@
 }
 
 .fa-user, .fa-user-circle {
-  --reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-user-small.svg);
+  --reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-user-small.svg);
 }
 
 .fa-user-cog {
-  --reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-gear-small.svg);
+  --reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-gear-small.svg);
 }
 
 .fa-users {
-  --reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-users-small.svg);
+  --reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-users-small.svg);
 }
 
 .fa-file {
-  --reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-page-small.svg);
+  --reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-page-small.svg);
 }
 
 .fa-edit {
-  --reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-pencil-small.svg);
+  --reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-pencil-small.svg);
 }
 
 .fa-history {
-  --reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-clock-small.svg);
+  --reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-clock-small.svg);
 }
 
 .fa-thumbs-up {
-  --reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-heart-small.svg);
+  --reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-heart-small.svg);
 }
 
 /*# sourceMappingURL=reverb.specialNotifications.fandomdesktop.css.map */

--- a/resources/css/reverb.specialNotifications.fandomdesktop.scss
+++ b/resources/css/reverb.specialNotifications.fandomdesktop.scss
@@ -39,7 +39,7 @@
 	&-icon {
 		width: 18px;
 		height: 18px;
-		@include svgAsBackground(url(/resources-ucp/v2/dist/svg/wds-icons-controls-small.svg), currentColor);
+		@include svgAsBackground(url(/resources-ucp/mw139/dist/svg/wds-icons-controls-small.svg), currentColor);
 	}
 
 	&-row {
@@ -75,11 +75,11 @@
 	}
 
 	&-checkbox--unchecked {
-		@include svgAsBackground(url(/resources-ucp/v2/dist/svg/wds-icons-checkbox-empty-small.svg), currentColor);
+		@include svgAsBackground(url(/resources-ucp/mw139/dist/svg/wds-icons-checkbox-empty-small.svg), currentColor);
 	}
 
 	&-checkbox--checked {
-		@include svgAsBackground(url(/resources-ucp/v2/dist/svg/wds-icons-checkbox-small.svg), var(--theme-link-color));
+		@include svgAsBackground(url(/resources-ucp/mw139/dist/svg/wds-icons-checkbox-small.svg), var(--theme-link-color));
 	}
 }
 
@@ -222,23 +222,23 @@
 }
 
 .fa-user, .fa-user-circle {
-	--reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-user-small.svg);
+	--reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-user-small.svg);
 }
 .fa-user-cog {
-	--reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-gear-small.svg);
+	--reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-gear-small.svg);
 }
 .fa-users {
-	--reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-users-small.svg);
+	--reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-users-small.svg);
 }
 .fa-file {
-	--reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-page-small.svg);
+	--reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-page-small.svg);
 }
 .fa-edit {
-	--reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-pencil-small.svg);
+	--reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-pencil-small.svg);
 }
 .fa-history {
-	--reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-clock-small.svg);
+	--reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-clock-small.svg);
 }
 .fa-thumbs-up {
-	--reverb-icon: url(/resources-ucp/v2/dist/svg/wds-icons-heart-small.svg);
+	--reverb-icon: url(/resources-ucp/mw139/dist/svg/wds-icons-heart-small.svg);
 }

--- a/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
+++ b/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
@@ -51,7 +51,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 
 		return [
 			[
-				'<img src="/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+				'<img src="/extensions-ucp/v2/Cheevos/images/gp30.png"',
 				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 			],
 			[
@@ -59,7 +59,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 			],
 			[
-				'<img src="/extensions-ucp/mw139/mw139/Cheevos/images/gp30.png"',
+				'<img src="/extensions-ucp/v2/mw139/Cheevos/images/gp30.png"',
 				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 			],
 			[
@@ -67,7 +67,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 			],
 			[
-				'<img src="/extensions-ucp/mw139/mw139/C/x.png"',
+				'<img src="/extensions-ucp/v2/v2/C/x.png"',
 				'<img src="fandom.com/extensions-ucp/mw139/v2/C/x.png"',
 			],
 			[

--- a/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
+++ b/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
@@ -51,7 +51,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 
 		return [
 			[
-				'<img src="/extensions-ucp/v2/Cheevos/images/gp30.png"',
+				'<img src="/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 			],
 			[
@@ -59,7 +59,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 			],
 			[
-				'<img src="/extensions-ucp/v2/mw139/Cheevos/images/gp30.png"',
+				'<img src="/extensions-ucp/mw139/mw139/Cheevos/images/gp30.png"',
 				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 			],
 			[
@@ -67,7 +67,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
 			],
 			[
-				'<img src="/extensions-ucp/v2/v2/C/x.png"',
+				'<img src="/extensions-ucp/mw139/mw139/C/x.png"',
 				'<img src="fandom.com/extensions-ucp/mw139/v2/C/x.png"',
 			],
 			[


### PR DESCRIPTION
https://fandom.atlassian.net/browse/PLATFORM-8565

We need to switch resources paths from v2 (MediaWiki 1.37) to mw139 (MW 1.39) as we want to remove deployment of MediaWiki 1.37 from all envs