### PR TITLE
PLATFORM-10519 fix: url fixer should fix urls to the current active extensions path rather than a hardcoded mw version

### DIFF
--- a/src/Api/ApiNotifications.php
+++ b/src/Api/ApiNotifications.php
@@ -15,6 +15,7 @@ namespace Reverb\Api;
 use Exception;
 use MediaWiki\Api\ApiBase;
 use MediaWiki\Config\Config;
+use MediaWiki\MainConfigNames;
 use Reverb\Fixer\NotificationUserNoteAssetsUrlFixer;
 use Reverb\Notification\NotificationService;
 use Wikimedia\ParamValidator\ParamValidator;
@@ -95,7 +96,10 @@ class ApiNotifications extends ApiBase {
 		}
 
 		foreach ( $bundle->getNotifications() as $key => $notification ) {
-			$result['notifications'][] = $this->notificationUserNoteAssetsUrlFixer->fix( $notification->toArray() );
+			$result['notifications'][] = $this->notificationUserNoteAssetsUrlFixer->fix(
+				$notification->toArray(),
+				$this->config->get( MainConfigNames::ExtensionAssetsPath )
+			);
 		}
 		$result['meta'] = [
 			'unread' => $bundle->getUnreadCount(),

--- a/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
+++ b/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
@@ -9,7 +9,7 @@ use MediaWiki\MediaWikiServices;
 
 final class NotificationUserNoteAssetsUrlFixer {
 	private const REGEX =
-		'/(?:<img\s+[^>]*?\bsrc=["\'].*(?<extPath>extensions-ucp\/(?:v2\/)?(?:mw[0-9]{3})?))/m';
+		'/(?:<img\s+[^>]*?\bsrc=["\'].*(?<extPath>\/extensions-ucp(?:\/v2)?(?:\/mw[0-9]{3})?))/m';
 
 	public function __construct( private readonly string $domain ) {
 	}
@@ -33,9 +33,9 @@ final class NotificationUserNoteAssetsUrlFixer {
 	}
 
 	private function replaceNotificationImgAssetUrl( $userNote ): array|string|null {
-		$extensionAssetsPath = ltrim( MediaWikiServices::getInstance()->getMainConfig()->get(
+		$extensionAssetsPath = MediaWikiServices::getInstance()->getMainConfig()->get(
 			MainConfigNames::ExtensionAssetsPath
-		), '/' );
+		);
 		return preg_replace_callback( self::REGEX, static function ( $matches ) use ( $extensionAssetsPath
 		): string|array {
 			return str_replace( $matches['extPath'], $extensionAssetsPath, $matches[0] );

--- a/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
+++ b/src/Fixer/NotificationUserNoteAssetsUrlFixer.php
@@ -4,9 +4,6 @@ declare( strict_types=1 );
 
 namespace Reverb\Fixer;
 
-use MediaWiki\MainConfigNames;
-use MediaWiki\MediaWikiServices;
-
 final class NotificationUserNoteAssetsUrlFixer {
 	private const REGEX =
 		'/(?:<img\s+[^>]*?\bsrc=["\'].*(?<extPath>\/extensions-ucp(?:\/v2)?(?:\/mw[0-9]{3})?))/m';
@@ -14,12 +11,15 @@ final class NotificationUserNoteAssetsUrlFixer {
 	public function __construct( private readonly string $domain ) {
 	}
 
-	public function fix( array $notification ): array {
+	public function fix( array $notification, $extensionAssetsPath ): array {
 		if ( !isset( $notification['user_note'] ) ) {
 			return $notification;
 		}
 
-		$notification['user_note'] = $this->replaceNotificationImgAssetUrl( $notification['user_note'] );
+		$notification['user_note'] = $this->replaceNotificationImgAssetUrl(
+			$notification['user_note'],
+			$extensionAssetsPath
+		);
 
 		// replace relative path with full urls, so notifications displayed outside of wiki context
 		// (i.e. fandom.com page) work well
@@ -32,10 +32,7 @@ final class NotificationUserNoteAssetsUrlFixer {
 		return $notification;
 	}
 
-	private function replaceNotificationImgAssetUrl( $userNote ): array|string|null {
-		$extensionAssetsPath = MediaWikiServices::getInstance()->getMainConfig()->get(
-			MainConfigNames::ExtensionAssetsPath
-		);
+	private function replaceNotificationImgAssetUrl( $userNote, $extensionAssetsPath ): array|string|null {
 		return preg_replace_callback( self::REGEX, static function ( $matches ) use ( $extensionAssetsPath
 		): string|array {
 			return str_replace( $matches['extPath'], $extensionAssetsPath, $matches[0] );

--- a/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
+++ b/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
@@ -19,7 +19,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 			'user_note' => $input
 		];
 
-		$fixedNotification = $fixer->fix( $notificationInput );
+		$fixedNotification = $fixer->fix( $notificationInput, '/extensions-ucp/mw143' );
 
 		self::assertSame( $expectedResult, $fixedNotification['user_note'] );
 	}

--- a/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
+++ b/tests/Unit/Fixer/NotificationUserNoteAssetsUrlFixerTest.php
@@ -24,7 +24,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 		self::assertSame( $expectedResult, $fixedNotification['user_note'] );
 	}
 
-	public function cheevosDataProvider(): array {
+	public static function cheevosDataProvider(): array {
 		$fullNotification = '
 			<div class=\'reverb-npn-ach\'>
 				<div class=\'reverb-npn-ach-text\'>
@@ -44,7 +44,7 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 					<div class=\'reverb-npn-ach-description\'>Visit the Achievements Special Page.</div>
 				</div>
 				<div class=\'reverb-npn-ach-points\'>10
-					<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png" />
+					<img src="fandom.com/extensions-ucp/mw143/Cheevos/images/gp30.png" />
 				</div>
 			</div>
 		';
@@ -52,23 +52,23 @@ class NotificationUserNoteAssetsUrlFixerTest extends TestCase {
 		return [
 			[
 				'<img src="/extensions-ucp/v2/Cheevos/images/gp30.png"',
-				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+				'<img src="fandom.com/extensions-ucp/mw143/Cheevos/images/gp30.png"',
 			],
 			[
 				'<img src="/extensions-ucp/mw139/Cheevos/images/gp30.png"',
-				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+				'<img src="fandom.com/extensions-ucp/mw143/Cheevos/images/gp30.png"',
 			],
 			[
 				'<img src="/extensions-ucp/v2/mw139/Cheevos/images/gp30.png"',
-				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+				'<img src="fandom.com/extensions-ucp/mw143/Cheevos/images/gp30.png"',
 			],
 			[
 				'<img src="/extensions-ucp/Cheevos/images/gp30.png"',
-				'<img src="fandom.com/extensions-ucp/mw139/Cheevos/images/gp30.png"',
+				'<img src="fandom.com/extensions-ucp/mw143/Cheevos/images/gp30.png"',
 			],
 			[
 				'<img src="/extensions-ucp/v2/v2/C/x.png"',
-				'<img src="fandom.com/extensions-ucp/mw139/v2/C/x.png"',
+				'<img src="fandom.com/extensions-ucp/mw143/v2/C/x.png"',
 			],
 			[
 				$fullNotification,


### PR DESCRIPTION
also cleans up the replace logic, uses the correct config variable to figure out the path, and speeds up the regex (if my benchmark is correct)